### PR TITLE
Add Kubernetes manifests for deployment

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-health-monitor
+  namespace: cluster-health-monitor
+  labels:
+    app: cluster-health-monitor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-health-monitor
+  template:
+    metadata:
+      labels:
+        app: cluster-health-monitor
+    spec:
+      serviceAccountName: cluster-health-monitor
+      containers:
+        - name: cluster-health-monitor
+          # TODO: Update the image to the correct registry and tag.
+          image: cluster-health-monitor:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9800
+              name: metrics
+          resources:
+            requests:
+              cpu: 20m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespaces.yaml
+  - rbac.yaml
+  - deployment.yaml

--- a/manifests/base/namespaces.yaml
+++ b/manifests/base/namespaces.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cluster-health-monitor

--- a/manifests/base/rbac.yaml
+++ b/manifests/base/rbac.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-health-monitor
+  namespace: cluster-health-monitor
+---
+# Role for accessing kube-dns and endpointslices in kube-system.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cluster-health-monitor-kube-system-reader
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources: ["services"]
+    resourceNames: ["kube-dns"]
+    verbs: ["get"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cluster-health-monitor-kube-system-reader
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: cluster-health-monitor
+    namespace: cluster-health-monitor
+roleRef:
+  kind: Role
+  name: cluster-health-monitor-kube-system-reader
+  apiGroup: rbac.authorization.k8s.io
+# TODO: Add a pod management role for pod startup check.


### PR DESCRIPTION
This PR introduces manifests file to deploy the cluster health monitor application, including its namespace, RBAC configuration, and kustomization setup.

Test locally by:
1. Building the docker image locally:
    ```bash
    docker build -f docker/cluster-health-monitor.Dockerfile -t cluster-health-monitor:latest .
    ```
1. Deploy the application:
    ```bash
    kubectl apply -k manifests/base/
    ```

# Changes
* Added a deployment configuration for the `cluster-health-monitor` application exposing metrics on port 9800.
* Created a dedicated namespace, `cluster-health-monitor`, for the application.
* Configured a service account, role, and role binding to grant the application read access to `kube-dns` and `endpointslices` in the `kube-system` namespace.
* Added a kustomization file to manage resources for the application.