### PR TITLE
bump manifest to v0.0.8

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
         - name: cluster-health-monitor
           # TODO: Update the image to the latest version.
-          image: mcr.microsoft.com/aks/cluster-health-monitor/cluster-health-monitor:v0.0.6
+          image: mcr.microsoft.com/aks/cluster-health-monitor/cluster-health-monitor:v0.0.8
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9800


### PR DESCRIPTION
Bumps the manifest to use the latest cluster-health-monitor release