### PR TITLE
Add node provisioning test config to Pod Startup Checker

### DIFF
--- a/pkg/checker/nodeprovisioning/errors.go
+++ b/pkg/checker/nodeprovisioning/errors.go
@@ -1,0 +1,10 @@
+package nodeprovisioning
+
+const (
+	// This is the error code of the PodStartupCheckers's result.
+	errCodePodCreationError           = "pod_creation_error"
+	errCodePodCreationTimeout         = "pod_creation_timeout"
+	errCodePodStartupDurationExceeded = "pod_startup_duration_exceeded"
+	errCodeRequestFailed              = "request_failed"
+	errCodeRequestTimeout             = "request_timeout"
+)

--- a/pkg/checker/nodeprovisioning/nodeprovisioning.go
+++ b/pkg/checker/nodeprovisioning/nodeprovisioning.go
@@ -1,0 +1,347 @@
+package nodeprovisioning
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"github.com/Azure/cluster-health-monitor/pkg/checker"
+	"github.com/Azure/cluster-health-monitor/pkg/config"
+	"github.com/Azure/cluster-health-monitor/pkg/types"
+)
+
+// Dialer is an interface for making network connections
+type Dialer interface {
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+const (
+	// syntheticPodImage is the hardcoded container image used for synthetic pods in pod-to-pod communication testing.
+	syntheticPodImage = "mcr.microsoft.com/azurelinux/base/nginx:1.25.4-4-azl3.0.20250702"
+
+	// syntheticPodPort is the hardcoded TCP port that synthetic pods listen on for connectivity testing.
+	syntheticPodPort = 80
+)
+
+type NodeProvisioningChecker struct {
+	name         string
+	config       *config.NodeProvisioningConfig
+	timeout      time.Duration
+	k8sClientset kubernetes.Interface
+	dialer       Dialer
+}
+
+// How often to poll the pod status to check if the container is running.
+var pollingInterval = 1 * time.Second // used for unit tests
+
+// The regular expression used to parse the image pull duration from a k8s event message for successfully pulling an image.
+var imagePullDurationRegex = regexp.MustCompile(`\(([a-zA-Z0-9\.]+) including waiting\)`)
+
+func Register() {
+	checker.RegisterChecker(config.CheckTypeNodeProvisioning, BuildNodeProvisioningChecker)
+}
+
+// BuildNodeProvisioningChecker creates a new NodeProvisioningChecker instance.
+func BuildNodeProvisioningChecker(config *config.CheckerConfig, kubeClient kubernetes.Interface) (checker.Checker, error) {
+	chk := &NodeProvisioningChecker{
+		name:         config.Name,
+		config:       config.NodeProvisioningConfig,
+		timeout:      config.Timeout,
+		k8sClientset: kubeClient,
+		dialer: &net.Dialer{
+			Timeout: config.NodeProvisioningConfig.TCPTimeout,
+		},
+	}
+	klog.InfoS("Built NodeProvisioningChecker",
+		"name", chk.name,
+		"config", chk.config,
+		"timeout", chk.timeout.String(),
+	)
+	return chk, nil
+}
+
+func (c *NodeProvisioningChecker) Name() string {
+	return c.name
+}
+
+func (c *NodeProvisioningChecker) Type() config.CheckerType {
+	return config.CheckTypeNodeProvisioning
+}
+
+// Run executes the node provisioning checker logic. It creates synthetic pods to measure the startup time. The startup time is defined as the
+// duration between the pod creation and the container running, minus the image pull duration (including waiting). If it is within the
+// allowed limit, the checker is considered healthy. Otherwise, it is considered unhealthy. Before each run, the checker also attempts to
+// garbage collect any leftover synthetic pods from previous runs that may not have been previously deleted due to errors or other issues.
+func (c *NodeProvisioningChecker) Run(ctx context.Context) (*types.Result, error) {
+	// Garbage collect any leftover synthetic pods previously created by this checker.
+	if err := c.garbageCollect(ctx); err != nil {
+		// Logging instead of returning an error here to avoid failing the checker run.
+		klog.ErrorS(err, "Failed to garbage collect old synthetic pods")
+	}
+
+	// List pods to check the current number of synthetic pods. Do not run the checker if the maximum number of synthetic pods has been reached.
+	pods, err := c.k8sClientset.CoreV1().Pods(c.config.SyntheticPodNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labels.Set(c.syntheticPodLabels())).String(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pods: %w", err)
+	}
+	if len(pods.Items) >= c.config.MaxSyntheticPods {
+		return nil, fmt.Errorf("maximum number of synthetic pods reached, current: %d, max allowed: %d, delete some pods before running the checker again",
+			len(pods.Items), c.config.MaxSyntheticPods)
+	}
+
+	// Create a synthetic pod to measure the startup time.
+	synthPod, err := c.k8sClientset.CoreV1().Pods(c.config.SyntheticPodNamespace).Create(ctx, c.generateSyntheticPod(), metav1.CreateOptions{})
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return types.Unhealthy(errCodePodCreationTimeout, "timed out creating synthetic pod"), nil
+		}
+		return types.Unhealthy(errCodePodCreationError, fmt.Sprintf("error creating synthetic pod: %s", err)), nil
+	}
+	defer func() {
+		err := c.k8sClientset.CoreV1().Pods(c.config.SyntheticPodNamespace).Delete(ctx, synthPod.Name, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			// Logging instead of returning an error here to avoid failing the checker run.
+			klog.ErrorS(err, "Failed to delete synthetic pod", "name", synthPod.Name)
+		}
+	}()
+
+	podCreationToContainerRunningDuration, err := c.pollPodCreationToContainerRunningDuration(ctx, synthPod.Name)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return types.Unhealthy(errCodePodStartupDurationExceeded, "pod has no running container"), nil
+		}
+		return nil, fmt.Errorf("pod has no running container: %w", err)
+	}
+	imagePullDuration, err := c.getImagePullDuration(ctx, synthPod.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get image pull duration: %w", err)
+	}
+
+	// Calculate the pod startup duration. Round to the seconds place because that is the unit of the least precise measurement.
+	podStartupDuration := (podCreationToContainerRunningDuration - imagePullDuration).Round(time.Second)
+	if podStartupDuration >= c.config.SyntheticPodStartupTimeout {
+		return types.Unhealthy(errCodePodStartupDurationExceeded, "pod exceeded the maximum healthy startup duration"), nil
+	}
+
+	// perform pod communication check - get pod IP and create TCP connection
+	podIP, err := c.getSyntheticPodIP(ctx, synthPod.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get synthetic pod IP: %w", err)
+	}
+
+	err = c.createTCPConnection(ctx, podIP)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return types.Unhealthy(errCodeRequestTimeout, "TCP request to synthetic pod timed out"), nil
+		}
+		return types.Unhealthy(errCodeRequestFailed, fmt.Sprintf("TCP request to synthetic pod failed: %s", err)), nil
+	}
+
+	return types.Healthy(), nil
+}
+
+// garbageCollect deletes all pods created by the checker that are older than the checker's timeout.
+func (c *NodeProvisioningChecker) garbageCollect(ctx context.Context) error {
+	podList, err := c.k8sClientset.CoreV1().Pods(c.config.SyntheticPodNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labels.Set(c.syntheticPodLabels())).String(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list pods for garbage collection: %w", err)
+	}
+	var errs []error
+	for _, pod := range podList.Items {
+		if time.Since(pod.CreationTimestamp.Time) > c.timeout {
+			err := c.k8sClientset.CoreV1().Pods(c.config.SyntheticPodNamespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
+				errs = append(errs, fmt.Errorf("failed to delete old synthetic pod %s: %w", pod.Name, err))
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// Returns the duration between the pod creation and the container running. This is precise to the second.
+func (c *NodeProvisioningChecker) pollPodCreationToContainerRunningDuration(ctx context.Context, podName string) (time.Duration, error) {
+	var podCreationToContainerRunningDuration time.Duration
+	err := wait.PollUntilContextCancel(ctx, pollingInterval, true, func(ctx context.Context) (bool, error) {
+		pod, err := c.k8sClientset.CoreV1().Pods(c.config.SyntheticPodNamespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		if len(pod.Status.ContainerStatuses) == 0 {
+			return false, nil
+		}
+		for _, status := range pod.Status.ContainerStatuses {
+			if status.State.Running != nil {
+				containerRunningTime := status.State.Running.StartedAt.Time
+				podCreationToContainerRunningDuration = containerRunningTime.Sub(pod.CreationTimestamp.Time)
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	return podCreationToContainerRunningDuration, err
+}
+
+// Returns the image pull duration including waiting time. This is precise to the millisecond.
+func (c *NodeProvisioningChecker) getImagePullDuration(ctx context.Context, podName string) (time.Duration, error) {
+	events, err := c.k8sClientset.CoreV1().Events(c.config.SyntheticPodNamespace).List(ctx, metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("involvedObject.name=%s,reason=Pulled", podName),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to list events for pod %s: %w", podName, err)
+	}
+
+	// events with reason=Pulled have messages expected to be in one of two formats:
+	// 1. "Successfully pulled image \"k8s.gcr.io/pause:3.2\" in 426ms (426ms including waiting). Image size: 299513 bytes."
+	// 2. "Container image \"k8s.gcr.io/pause:3.2\" already present on machine"
+	for _, event := range events.Items {
+		if strings.Contains(event.Message, "Successfully pulled image") {
+			return c.parseImagePullDuration(event.Message)
+		}
+		if strings.Contains(event.Message, "already present on machine") {
+			return 0, nil
+		}
+		// Logging instead of returning an error to avoid failing the checker run.
+		klog.InfoS("Unexpected event message format for pod", "name", podName, "message", event.Message)
+	}
+	return 0, fmt.Errorf("no image pull events found for pod %s", podName)
+}
+
+// Parses the image pull duration (including waiting) from a kubernetes event message expected to be in a format like:
+// "Successfully pulled image \"k8s.gcr.io/pause:3.2\" in 426ms (426ms including waiting). Image size: 299513 bytes." or
+// "Successfully pulled image \"k8s.gcr.io/pause:3.2\" in 426ms (1s34ms including waiting). Image size: 299513 bytes."
+func (c *NodeProvisioningChecker) parseImagePullDuration(message string) (time.Duration, error) {
+	matches := imagePullDurationRegex.FindStringSubmatch(message)
+	if len(matches) != 2 {
+		return 0, fmt.Errorf("failed to extract image pull duration from event message: message in unexpected format: %s", message)
+	}
+	return time.ParseDuration(matches[1])
+}
+
+func (c *NodeProvisioningChecker) syntheticPodLabels() map[string]string {
+	return map[string]string{
+		// c.name is supposed to be a unique identifier for each checker. Using this as the label value to ensure that synthetic pods
+		// created by different checkers do not conflict with each other.
+		c.config.SyntheticPodLabelKey: c.name,
+	}
+}
+
+func (c *NodeProvisioningChecker) syntheticPodNamePrefix() string {
+	// The synthetic pod name prefix is used as an additional safety measure to ensure that the checker only operates on its own synthetic pods.
+	// c.name is supposed to be a unique identifier for each checker, so this prefix should be unique across all checkers.
+	return strings.ToLower(fmt.Sprintf("%s-synthetic-", c.name))
+}
+
+func (c *NodeProvisioningChecker) generateSyntheticPod() *corev1.Pod {
+	podName := fmt.Sprintf("%s%d", c.syntheticPodNamePrefix(), time.Now().UnixNano())
+
+	podSpec := corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:  "synthetic",
+				Image: syntheticPodImage,
+				Ports: []corev1.ContainerPort{
+					{
+						ContainerPort: syntheticPodPort,
+						Protocol:      corev1.ProtocolTCP,
+					},
+				},
+			},
+		},
+		Tolerations: []corev1.Toleration{
+			{
+				Key:    "node-role.kubernetes.io/master",
+				Effect: corev1.TaintEffectNoSchedule,
+			},
+			{
+				Key:      "CriticalAddonsOnly",
+				Operator: corev1.TolerationOpExists,
+			},
+		},
+		Affinity: &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{
+									Key:      "kubernetes.azure.com/cluster",
+									Operator: corev1.NodeSelectorOpExists,
+								},
+								{
+									Key:      "type",
+									Operator: corev1.NodeSelectorOpNotIn,
+									Values:   []string{"virtual-kubelet"},
+								},
+								{
+									Key:      "kubernetes.io/os",
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{"linux"},
+								},
+								{
+									Key:      "kubernetes.azure.com/mode",
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{"system"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		// TODOcarlosalv: Add pod cpu/memory requests and/or limits.
+	}
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   podName,
+			Labels: c.syntheticPodLabels(),
+		},
+		Spec: podSpec,
+	}
+}
+
+// getSyntheticPodIP gets the IP address assigned to the synthetic pod with the specified name
+func (c *NodeProvisioningChecker) getSyntheticPodIP(ctx context.Context, podName string) (string, error) {
+	pod, err := c.k8sClientset.CoreV1().Pods(c.config.SyntheticPodNamespace).Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("error getting pod %s: %w", podName, err)
+	}
+	if pod.Status.PodIP == "" {
+		return "", fmt.Errorf("pod IP is empty")
+	}
+	return pod.Status.PodIP, nil
+}
+
+// createTCPConnection makes a simple TCP connection to the pod IP
+func (c *NodeProvisioningChecker) createTCPConnection(ctx context.Context, podIP string) error {
+	address := fmt.Sprintf("%s:%s", podIP, strconv.Itoa(syntheticPodPort))
+
+	conn, err := c.dialer.DialContext(ctx, "tcp", address)
+	if err != nil {
+		return fmt.Errorf("TCP connection failed: %w", err)
+	}
+	defer func() {
+		if err := conn.Close(); err != nil {
+			klog.ErrorS(err, "Failed to close TCP connection", "podIP", podIP)
+		}
+	}()
+
+	return nil
+}

--- a/pkg/checker/nodeprovisioning/nodeprovisioning_test.go
+++ b/pkg/checker/nodeprovisioning/nodeprovisioning_test.go
@@ -1,0 +1,738 @@
+package nodeprovisioning
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/Azure/cluster-health-monitor/pkg/config"
+	"github.com/Azure/cluster-health-monitor/pkg/types"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/validation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// =============================================================================
+// Test Helpers and Mocks
+// =============================================================================
+
+// Pod and Event creation helpers
+func podWithLabels(name string, namespace string, labels map[string]string, creationTime time.Time) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			Labels:            labels,
+			CreationTimestamp: metav1.NewTime(creationTime),
+		},
+	}
+}
+
+func imageSuccessfullyPulledEvent(namespace, podName string, pullDuration time.Duration) *corev1.Event {
+	return &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "event1"},
+		Message: fmt.Sprintf("Successfully pulled image \"k8s.gcr.io/pause:3.2\" in %s (%s including waiting). Image size: 299513 bytes.",
+			pullDuration, pullDuration),
+		Reason:         "Pulled",
+		InvolvedObject: corev1.ObjectReference{Name: podName},
+	}
+}
+
+func imageAlreadyPresentEvent(namespace, podName string) *corev1.Event {
+	return &corev1.Event{
+		ObjectMeta:     metav1.ObjectMeta{Namespace: namespace, Name: "event1"},
+		Message:        "Container image \"k8s.gcr.io/pause:3.2\" already present on machine",
+		Reason:         "Pulled",
+		InvolvedObject: corev1.ObjectReference{Name: podName},
+	}
+}
+
+// mockDialer is a mock implementation of the Dialer interface for testing
+type mockDialer struct {
+	dialFunc func(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+func (m *mockDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return m.dialFunc(ctx, network, address)
+}
+
+// Dialer creation helpers
+func successfulDialer() Dialer {
+	return &mockDialer{
+		dialFunc: func(ctx context.Context, network, address string) (net.Conn, error) {
+			conn, _ := net.Pipe()
+			return conn, nil
+		},
+	}
+}
+
+func failingDialer(errMsg string) Dialer {
+	return &mockDialer{
+		dialFunc: func(ctx context.Context, network, address string) (net.Conn, error) {
+			return nil, fmt.Errorf(errMsg, address)
+		},
+	}
+}
+
+// =============================================================================
+// Test Functions
+// =============================================================================
+
+func TestNodeProvisioningChecker_Run(t *testing.T) {
+	// Defines adjustable parameters for the test scenarios
+	type testScenario struct {
+		podName         string
+		namespace       string
+		labels          map[string]string
+		podIP           string
+		startupDelay    time.Duration
+		preExistingPods []string
+		hasDeleteError  bool
+		dialer          Dialer
+	}
+
+	// Mutator function type
+	type scenarioMutator func(*testScenario)
+
+	checkerName := "test"
+	syntheticPodNamespace := "test-namespace"
+	syntheticPodLabelKey := "cluster-health-monitor/checker-name"
+	maxSyntheticPods := 3
+
+	tests := []struct {
+		name           string
+		mutators       []scenarioMutator
+		validateResult func(g *WithT, result *types.Result, err error)
+	}{
+		{
+			name:     "healthy result - no pre-existing synthetic pods",
+			mutators: nil, // Use default scenario
+			validateResult: func(g *WithT, result *types.Result, err error) {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(result).ToNot(BeNil())
+				g.Expect(result.Status).To(Equal(types.StatusHealthy))
+			},
+		},
+		{
+			name: "unhealthy result - pod startup took too long",
+			mutators: []scenarioMutator{
+				func(s *testScenario) { s.startupDelay = 10 * time.Second },
+			},
+			validateResult: func(g *WithT, result *types.Result, err error) {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(result).ToNot(BeNil())
+				g.Expect(result.Status).To(Equal(types.StatusUnhealthy))
+				g.Expect(result.Detail.Code).To(Equal(errCodePodStartupDurationExceeded))
+			},
+		},
+		{
+			name: "error - max synthetic pods reached",
+			mutators: []scenarioMutator{
+				func(s *testScenario) {
+					for i := 0; i < maxSyntheticPods; i++ {
+						s.preExistingPods = append(s.preExistingPods, fmt.Sprintf("pod%d", i))
+					}
+					s.hasDeleteError = true
+				},
+			},
+			validateResult: func(g *WithT, result *types.Result, err error) {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("maximum number of synthetic pods reached"))
+			},
+		},
+		{
+			name: "error - fail to get pod IP",
+			mutators: []scenarioMutator{
+				func(s *testScenario) { s.podIP = "" },
+			},
+			validateResult: func(g *WithT, result *types.Result, err error) {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("failed to get synthetic pod IP"))
+			},
+		},
+		{
+			name: "unhealthy result - TCP dialer error",
+			mutators: []scenarioMutator{
+				func(s *testScenario) { s.dialer = failingDialer("error") },
+			},
+			validateResult: func(g *WithT, result *types.Result, err error) {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(result).ToNot(BeNil())
+				g.Expect(result.Status).To(Equal(types.StatusUnhealthy))
+				g.Expect(result.Detail.Code).To(Equal(errCodeRequestFailed))
+				g.Expect(result.Detail.Message).To(ContainSubstring("TCP request to synthetic pod failed"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			// Initialize default healthy scenario
+			scenario := &testScenario{
+				podName:        "pod1",
+				namespace:      syntheticPodNamespace,
+				labels:         map[string]string{syntheticPodLabelKey: checkerName},
+				podIP:          "10.0.0.0",
+				startupDelay:   3 * time.Second,
+				hasDeleteError: false,
+				dialer:         successfulDialer(),
+			}
+
+			// Apply mutators to modify the scenario
+			for _, mutator := range tt.mutators {
+				mutator(scenario)
+			}
+
+			// Build the test client and setup
+			events := []runtime.Object{imageAlreadyPresentEvent(scenario.namespace, scenario.podName)}
+			client := k8sfake.NewClientset(events...)
+
+			// Add pre-existing pods if any
+			podCreationTimestamp := time.Now()
+			for _, podName := range scenario.preExistingPods {
+				pod := podWithLabels(podName, scenario.namespace, scenario.labels, podCreationTimestamp)
+				client.CoreV1().Pods(scenario.namespace).Create(context.Background(), pod, metav1.CreateOptions{}) //nolint:errcheck
+			}
+
+			// Create the main test pod
+			fakePod := podWithLabels(scenario.podName, scenario.namespace, scenario.labels, podCreationTimestamp)
+			fakePod.Status = corev1.PodStatus{
+				PodIP: scenario.podIP,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(podCreationTimestamp.Add(scenario.startupDelay))},
+					},
+				}},
+			}
+
+			// Add reactors
+			client.PrependReactor("create", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				return true, fakePod, nil
+			})
+			client.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				return true, fakePod, nil
+			})
+			client.PrependReactor("delete", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				if scenario.hasDeleteError {
+					return true, nil, errors.New("error occurred")
+				}
+				return true, fakePod, nil
+			})
+
+			nodeProvisioningChecker := &NodeProvisioningChecker{
+				name: checkerName,
+				config: &config.NodeProvisioningConfig{
+					SyntheticPodNamespace:      syntheticPodNamespace,
+					SyntheticPodLabelKey:       syntheticPodLabelKey,
+					SyntheticPodStartupTimeout: 5 * time.Second,
+					MaxSyntheticPods:           maxSyntheticPods,
+				},
+				timeout:      5 * time.Second,
+				k8sClientset: client,
+				dialer:       scenario.dialer,
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), nodeProvisioningChecker.timeout)
+			defer cancel()
+
+			result, err := nodeProvisioningChecker.Run(ctx)
+			tt.validateResult(g, result, err)
+		})
+	}
+}
+
+func TestPodStartupChecker_garbageCollect(t *testing.T) {
+	checkerName := "chk"
+	syntheticPodNamespace := "checker-ns"
+	checkerTimeout := 5 * time.Second
+	syntheticPodLabelKey := "cluster-health-monitor/checker-name"
+
+	tests := []struct {
+		name        string
+		client      *k8sfake.Clientset
+		validateRes func(g *WithT, pods *corev1.PodList, err error)
+	}{
+		{
+			name: "only removes pods older than timeout",
+			client: k8sfake.NewClientset(
+				podWithLabels("chk-synthetic-old", syntheticPodNamespace, map[string]string{syntheticPodLabelKey: checkerName}, time.Now().Add(-2*time.Hour)),
+				podWithLabels("chk-synthetic-new", syntheticPodNamespace, map[string]string{syntheticPodLabelKey: checkerName}, time.Now()),
+			),
+			validateRes: func(g *WithT, pods *corev1.PodList, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(pods.Items).To(HaveLen(1))
+				g.Expect(pods.Items[0].Name).To(Equal("chk-synthetic-new"))
+			},
+		},
+		{
+			name: "no pods to delete",
+			client: k8sfake.NewClientset(
+				podWithLabels("chk-synthetic-too-new", syntheticPodNamespace, map[string]string{syntheticPodLabelKey: checkerName}, time.Now()), // pod too new
+				podWithLabels("chk-synthetic-no-labels", syntheticPodNamespace, map[string]string{}, time.Now().Add(-2*time.Hour)),              // old pod wrong labels
+				podWithLabels("no-name-prefix", syntheticPodNamespace, map[string]string{}, time.Now().Add(-2*time.Hour)),                       // pod missing name prefix
+			),
+			validateRes: func(g *WithT, pods *corev1.PodList, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(pods.Items).To(HaveLen(3))
+				actualNames := make([]string, len(pods.Items))
+				for i, pod := range pods.Items {
+					actualNames[i] = pod.Name
+				}
+				g.Expect(actualNames).To(ConsistOf([]string{"chk-synthetic-too-new", "chk-synthetic-no-labels", "no-name-prefix"}))
+			},
+		},
+		{
+			name: "only removes pod with checker labels",
+			client: k8sfake.NewClientset(
+				podWithLabels("chk-synthetic-pod", syntheticPodNamespace, map[string]string{syntheticPodLabelKey: checkerName}, time.Now().Add(-2*time.Hour)),
+				podWithLabels("chk-synthetic-no-label-pod", syntheticPodNamespace, map[string]string{}, time.Now().Add(-2*time.Hour)),
+			),
+			validateRes: func(g *WithT, pods *corev1.PodList, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(pods.Items).To(HaveLen(1))
+				g.Expect(pods.Items[0].Name).To(Equal("chk-synthetic-no-label-pod"))
+			},
+		},
+		{
+			name: "error listing pods",
+			client: func() *k8sfake.Clientset {
+				client := k8sfake.NewClientset()
+				client.PrependReactor("list", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					// fail the List call in garbageCollect because it uses a label selector. This prevents breaking the test which also
+					// lists pods but does not use a selector.
+					listAction, ok := action.(k8stesting.ListAction)
+					if ok && listAction.GetListRestrictions().Labels.String() != "" {
+						return true, nil, errors.New("error bad things")
+					}
+					return false, nil, nil
+				})
+				return client
+			}(),
+			validateRes: func(g *WithT, pods *corev1.PodList, err error) {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("failed to list pods for garbage collection"))
+			},
+		},
+		{
+			name: "error deleting pod",
+			client: func() *k8sfake.Clientset {
+				client := k8sfake.NewClientset(
+					podWithLabels("chk-synthetic-pod-1", syntheticPodNamespace, map[string]string{syntheticPodLabelKey: checkerName}, time.Now().Add(-2*time.Hour)),
+					podWithLabels("chk-synthetic-pod-2", syntheticPodNamespace, map[string]string{syntheticPodLabelKey: checkerName}, time.Now().Add(-2*time.Hour)),
+				)
+				// only fail the Delete call for old-pod-1
+				client.PrependReactor("delete", "pods", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					deleteAction, ok := action.(k8stesting.DeleteAction)
+					if ok && deleteAction.GetName() == "chk-synthetic-pod-1" {
+						return true, nil, errors.New("error bad things")
+					}
+					return false, nil, nil
+				})
+				return client
+			}(),
+			validateRes: func(g *WithT, pods *corev1.PodList, err error) {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("failed to delete old synthetic pod"))
+				g.Expect(pods.Items).To(HaveLen(1)) // one pod should be deleted
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			checker := &NodeProvisioningChecker{
+				name: checkerName,
+				config: &config.NodeProvisioningConfig{
+					SyntheticPodNamespace:      syntheticPodNamespace,
+					SyntheticPodLabelKey:       syntheticPodLabelKey,
+					SyntheticPodStartupTimeout: 3 * time.Second,
+					MaxSyntheticPods:           5,
+				},
+				timeout:      checkerTimeout,
+				k8sClientset: tt.client,
+			}
+
+			// Run garbage collect
+			err := checker.garbageCollect(context.Background())
+
+			// Get pods for validation
+			pods, listErr := tt.client.CoreV1().Pods(syntheticPodNamespace).List(context.Background(), metav1.ListOptions{})
+			g.Expect(listErr).NotTo(HaveOccurred())
+
+			tt.validateRes(g, pods, err)
+		})
+	}
+}
+
+func TestPodStartupChecker_pollPodCreationToContainerRunningDuration(t *testing.T) {
+	podName := "pod1"
+	syntheticPodNamespace := "test"
+	timestamp := time.Now()
+	tests := []struct {
+		name        string
+		pod         *corev1.Pod
+		validateRes func(g *WithT, duration time.Duration, err error)
+	}{
+		{
+			name: "container running",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              podName,
+					Namespace:         syntheticPodNamespace,
+					CreationTimestamp: metav1.NewTime(timestamp.Add(-10 * time.Second)),
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{{
+						State: corev1.ContainerState{
+							Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(timestamp)},
+						},
+					}},
+				},
+			},
+			validateRes: func(g *WithT, duration time.Duration, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(duration).To(Equal(10 * time.Second))
+			},
+		},
+		{
+			name: "error - polling timeout occurred",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: syntheticPodNamespace,
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{{
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{},
+						},
+					}},
+				},
+			},
+			validateRes: func(g *WithT, duration time.Duration, err error) {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(Equal(context.DeadlineExceeded))
+				g.Expect(duration).To(Equal(0 * time.Second))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			client := k8sfake.NewClientset()
+			if tt.pod != nil {
+				client.CoreV1().Pods(syntheticPodNamespace).Create(context.Background(), tt.pod, metav1.CreateOptions{}) //nolint:errcheck // ignore error for test setup
+			}
+			checker := &NodeProvisioningChecker{
+				k8sClientset: client,
+				config: &config.NodeProvisioningConfig{
+					SyntheticPodNamespace:      syntheticPodNamespace,
+					SyntheticPodLabelKey:       "cluster-health-monitor/checker-name",
+					SyntheticPodStartupTimeout: 5 * time.Second,
+					MaxSyntheticPods:           3,
+				},
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+
+			dur, err := checker.pollPodCreationToContainerRunningDuration(ctx, podName)
+			tt.validateRes(g, dur, err)
+		})
+	}
+}
+
+func TestPodStartupChecker_parseImagePullDuration(t *testing.T) {
+	checker := &NodeProvisioningChecker{}
+	tests := []struct {
+		name        string
+		msg         string
+		validateRes func(g *WithT, duration time.Duration, err error)
+	}{
+		{
+			name: "valid message - only ms",
+			msg:  "Successfully pulled image \"k8s.gcr.io/pause:3.2\" in 426ms (800ms including waiting). Image size: 299513 bytes.",
+			validateRes: func(g *WithT, duration time.Duration, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(duration).To(Equal(800 * time.Millisecond))
+			},
+		},
+		{
+			name: "valid message - sec and ms",
+			msg:  "Successfully pulled image \"k8s.gcr.io/pause:3.2\" in 426ms (1s34ms including waiting). Image size: 299513 bytes.",
+			validateRes: func(g *WithT, duration time.Duration, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(duration).To(Equal(1*time.Second + 34*time.Millisecond))
+			},
+		},
+		{
+			name: "valid message - seconds with decimal",
+			msg:  "Successfully pulled image \"k8s.gcr.io/pause:3.2\" in 2.149s (2.149s including waiting). Image size: 299513 bytes.",
+			validateRes: func(g *WithT, duration time.Duration, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(duration).To(Equal(2*time.Second + 149*time.Millisecond))
+			},
+		},
+		{
+			name: "invalid format",
+			msg:  "Successfully pulled image in foo (bar including waiting).",
+			validateRes: func(g *WithT, duration time.Duration, err error) {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(duration).To(Equal(0 * time.Millisecond))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			dur, err := checker.parseImagePullDuration(tt.msg)
+			tt.validateRes(g, dur, err)
+		})
+	}
+}
+
+func TestPodStartupChecker_getImagePullDuration(t *testing.T) {
+	podName := "pod1"
+	namespace := "testns"
+
+	tests := []struct {
+		name        string
+		client      *k8sfake.Clientset
+		validateRes func(g *WithT, duration time.Duration, err error)
+	}{
+		{
+			name: "valid image pulled event",
+			client: k8sfake.NewClientset(
+				imageSuccessfullyPulledEvent(namespace, podName, 800*time.Millisecond),
+			),
+			validateRes: func(g *WithT, duration time.Duration, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(duration).To(Equal(800 * time.Millisecond))
+			},
+		},
+		{
+			name: "valid image already present event",
+			client: k8sfake.NewClientset(
+				imageAlreadyPresentEvent(namespace, podName),
+			),
+			validateRes: func(g *WithT, duration time.Duration, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(duration).To(Equal(0 * time.Millisecond))
+			},
+		},
+		{
+			name:   "no events",
+			client: k8sfake.NewClientset(),
+			validateRes: func(g *WithT, duration time.Duration, err error) {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("no image pull events found"))
+			},
+		},
+		{
+			name: "error listing events",
+			client: func() *k8sfake.Clientset {
+				client := k8sfake.NewClientset()
+				client.PrependReactor(
+					"list", "events", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+						return true, nil, apierrors.NewInternalError(errors.New("error occurred"))
+					})
+				return client
+			}(),
+			validateRes: func(g *WithT, duration time.Duration, err error) {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("failed to list events"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			checker := &NodeProvisioningChecker{
+				config: &config.NodeProvisioningConfig{
+					SyntheticPodNamespace: namespace,
+				},
+				k8sClientset: tt.client,
+			}
+			dur, err := checker.getImagePullDuration(context.Background(), "test-pod")
+			tt.validateRes(g, dur, err)
+		})
+	}
+}
+
+func TestGenerateSyntheticPod(t *testing.T) {
+	tests := []struct {
+		name        string
+		checkerName string
+	}{
+		{
+			name:        "generates valid synthetic pod",
+			checkerName: "test",
+		},
+		{
+			name:        "succesfully handles uppercase checker name",
+			checkerName: "UPPERCASE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			checker := &NodeProvisioningChecker{
+				name: tt.checkerName,
+				config: &config.NodeProvisioningConfig{
+					SyntheticPodLabelKey: "cluster-health-monitor/checker-name",
+				},
+			}
+
+			pod := checker.generateSyntheticPod()
+			g.Expect(pod).ToNot(BeNil())
+
+			// Verify pod name is k8s compliant (DNS subdomain format)
+			g.Expect(validation.NameIsDNSSubdomain(pod.Name, false)).To(BeEmpty()) // this should not return any validation errors
+			g.Expect(pod.Name).To(HavePrefix(checker.syntheticPodNamePrefix()))
+			g.Expect(pod.Labels).To(Equal(checker.syntheticPodLabels()))
+		})
+	}
+}
+
+func TestPodStartupChecker_getSyntheticPodIP(t *testing.T) {
+	podName := "test-pod"
+	namespace := "test-namespace"
+
+	tests := []struct {
+		name        string
+		scenario    func() *k8sfake.Clientset
+		validateRes func(g *WithT, podIP string, err error)
+	}{
+		{
+			name: "successfully gets pod IP",
+			scenario: func() *k8sfake.Clientset {
+				client := k8sfake.NewClientset()
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      podName,
+						Namespace: namespace,
+					},
+					Status: corev1.PodStatus{
+						PodIP: "10.0.0.0",
+					},
+				}
+				client.CoreV1().Pods(namespace).Create(context.Background(), pod, metav1.CreateOptions{}) //nolint:errcheck
+				return client
+			},
+			validateRes: func(g *WithT, podIP string, err error) {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(podIP).To(Equal("10.0.0.0"))
+			},
+		},
+		{
+			name: "error - pod not found",
+			scenario: func() *k8sfake.Clientset {
+				return k8sfake.NewClientset()
+			},
+			validateRes: func(g *WithT, podIP string, err error) {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("error getting pod"))
+				g.Expect(podIP).To(BeEmpty())
+			},
+		},
+		{
+			name: "error - pod IP is empty",
+			scenario: func() *k8sfake.Clientset {
+				client := k8sfake.NewClientset()
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      podName,
+						Namespace: namespace,
+					},
+					Status: corev1.PodStatus{
+						PodIP: "",
+					},
+				}
+				client.CoreV1().Pods(namespace).Create(context.Background(), pod, metav1.CreateOptions{}) //nolint:errcheck
+				return client
+			},
+			validateRes: func(g *WithT, podIP string, err error) {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("pod IP is empty"))
+				g.Expect(podIP).To(BeEmpty())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			checker := &NodeProvisioningChecker{
+				config: &config.NodeProvisioningConfig{
+					SyntheticPodNamespace: namespace,
+				},
+				k8sClientset: tt.scenario(),
+			}
+
+			podIP, err := checker.getSyntheticPodIP(context.Background(), podName)
+			tt.validateRes(g, podIP, err)
+		})
+	}
+}
+
+func TestPodStartupChecker_makeTCPRequest(t *testing.T) {
+	tests := []struct {
+		name        string
+		podIP       string
+		dialer      Dialer
+		validateRes func(g *WithT, err error)
+	}{
+		{
+			name:   "successful TCP connection",
+			podIP:  "10.0.0.0",
+			dialer: successfulDialer(),
+			validateRes: func(g *WithT, err error) {
+				g.Expect(err).ToNot(HaveOccurred())
+			},
+		},
+		{
+			name:   "failed TCP connection",
+			podIP:  "10.0.0.0",
+			dialer: failingDialer("error occurred"),
+			validateRes: func(g *WithT, err error) {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("TCP connection failed"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			checker := &NodeProvisioningChecker{
+				dialer: tt.dialer,
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			err := checker.createTCPConnection(ctx, tt.podIP)
+			tt.validateRes(g, err)
+		})
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,10 +7,11 @@ import (
 type CheckerType string
 
 const (
-	CheckTypeDNS           CheckerType = "dns"
-	CheckTypePodStartup    CheckerType = "podStartup"
-	CheckTypeAPIServer     CheckerType = "apiServer"
-	CheckTypeMetricsServer CheckerType = "metricsServer"
+	CheckTypeDNS              CheckerType = "dns"
+	CheckTypePodStartup       CheckerType = "podStartup"
+	CheckTypeAPIServer        CheckerType = "apiServer"
+	CheckTypeMetricsServer    CheckerType = "metricsServer"
+	CheckTypeNodeProvisioning CheckerType = "nodeProvisioning"
 )
 
 // Config represents the configuration for the health checkers.
@@ -54,6 +55,10 @@ type CheckerConfig struct {
 	// Optional.
 	// The configuration for the API server checker, this field is required if Type is CheckTypeAPIServer.
 	APIServerConfig *APIServerConfig `yaml:"apiServerConfig,omitempty"`
+
+	// Optional.
+	// The configuration for the Node Provisioning checker, this field is required if Type is CheckTypeNodeProvisioning.
+	NodeProvisioningConfig *NodeProvisioningConfig `yaml:"nodeProvisioningConfig,omitempty"`
 }
 
 type DNSConfig struct {
@@ -72,6 +77,29 @@ type DNSConfig struct {
 }
 
 type PodStartupConfig struct {
+	// Required.
+	// The namespace in which synthetic pods are created.
+	SyntheticPodNamespace string `yaml:"syntheticPodNamespace"`
+	// Required.
+	// The Kubernetes label key used to identify synthetic pods created by the checker.
+	SyntheticPodLabelKey string `yaml:"syntheticPodLabelKey"`
+	// Required.
+	// The maximum synthetic pod startup duration for which the checker will return healthy status. Exceeding this duration will cause the
+	// checker to return unhealthy status. The pod startup duration is defined as the time between the pod's creation timestamp and the time
+	// its container starts running, minus the image pull duration (including waiting).
+	SyntheticPodStartupTimeout time.Duration `yaml:"syntheticPodStartupTimeout"`
+	// Required.
+	// The maximum number of synthetic pods created by the checker that can exist at any one time. If the limit has been reached, the checker
+	// will not create any more synthetic pods until some of the existing ones are deleted. Instead, it will fail the run with an error.
+	// Reaching this limit effectively disables the checker.
+	MaxSyntheticPods int `yaml:"maxSyntheticPods,omitempty"`
+	// Required.
+	// The maximum duration for which the checker will wait for a TCP connection to be established with a synthetic pod. Exceeding this
+	// duration will cause the checker to return unhealthy status.
+	TCPTimeout time.Duration `yaml:"tcpTimeout,omitempty"`
+}
+
+type NodeProvisioningConfig struct {
 	// Required.
 	// The namespace in which synthetic pods are created.
 	SyntheticPodNamespace string `yaml:"syntheticPodNamespace"`


### PR DESCRIPTION
This PR is adding a new Node Provisioning Checker for Automatic clusters. Currently the codes are copied from pod startup checker and just renamed, because the behavior will be similar.  Some functionality modification will be added in following PRs.