### PR TITLE
Add cluster role for node provisioning check in pod startup checker

### DIFF
--- a/manifests/base/rbac.yaml
+++ b/manifests/base/rbac.yaml
@@ -137,3 +137,44 @@ roleRef:
   kind: ClusterRole
   name: cluster-health-monitor-metrics-server-reader
   apiGroup: rbac.authorization.k8s.io
+---
+# ClusterRole for managing Karpenter NodePools. Used by the pod startup checker when enableNodeProvisioningTest is true.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-health-monitor-karpenter-admin
+rules:
+  - apiGroups: [ "apiextensions.k8s.io" ]
+    resources: [ "customresourcedefinitions" ]
+    resourceNames: [ "nodepools.karpenter.sh" ]
+    verbs: [ "get", "list" ]
+
+  # Core Karpenter v1beta1 APIs
+  - apiGroups: [ "karpenter.sh" ]
+    resources:
+      - nodepools
+      - nodepools/status
+      - nodeclaims
+      - nodeclaims/status
+    verbs: [ "get", "list", "create", "delete" ]
+
+  # Provider-specific NodeClass
+  - apiGroups: [ "karpenter.azure.com" ]
+    resources: [ "aksnodeclasses" ]
+    verbs: [ "get", "list", "watch" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-health-monitor-karpenter-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-health-monitor-karpenter-admin
+subjects:
+  - kind: ServiceAccount
+    name: cluster-health-monitor
+    namespace: kube-system
+---
+
+


### PR DESCRIPTION
Adds cluster role necessary to interact with karpenter nodepools for node provisioning check in pod startup checker