### PR TITLE
Add error code to CSI checker for invalid storage class

### DIFF
--- a/pkg/checker/podstartup/errors.go
+++ b/pkg/checker/podstartup/errors.go
@@ -7,4 +7,5 @@ const (
 	ErrCodePodStartupDurationExceeded = "PodStartupDurationExceeded"
 	ErrCodeRequestFailed              = "RequestFailed"
 	ErrCodeRequestTimeout             = "RequestTimeout"
+	ErrCodeStorageClassNotFound       = "StorageClassNotFound"
 )

--- a/pkg/checker/podstartup/podstartup.go
+++ b/pkg/checker/podstartup/podstartup.go
@@ -121,6 +121,13 @@ func (c *PodStartupChecker) check(ctx context.Context) (*checker.Result, error) 
 
 	timeStampStr := fmt.Sprintf("%d", time.Now().UnixNano())
 
+	if err := c.validateStorageClasses(ctx); err != nil {
+		if apierrors.IsNotFound(err) {
+			return checker.Unhealthy(ErrCodeStorageClassNotFound, err.Error()), nil
+		}
+		return nil, err
+	}
+
 	if err := c.checkCSIResourceLimit(ctx); err != nil {
 		return nil, fmt.Errorf("CSI resource limit check failed: %w", err)
 	}

--- a/pkg/checker/podstartup/podstartup_test.go
+++ b/pkg/checker/podstartup/podstartup_test.go
@@ -498,6 +498,8 @@ func TestPodStartupChecker_check(t *testing.T) {
 			validateResult: func(g *WithT, result *checker.Result, err error, fakeDynamicClient *dynamicfake.FakeDynamicClient) {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(ContainSubstring("failed to get StorageClass"))
+				g.Expect(err.Error()).To(ContainSubstring("internal server error"))
+				g.Expect(apierrors.IsNotFound(err)).To(BeFalse())
 			},
 		},
 	}

--- a/pkg/checker/podstartup/podstartup_test.go
+++ b/pkg/checker/podstartup/podstartup_test.go
@@ -13,6 +13,7 @@ import (
 	retry "github.com/avast/retry-go/v4"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -81,18 +82,21 @@ func failingDialer(errMsg string) Dialer {
 func TestPodStartupChecker_check(t *testing.T) {
 	// Defines adjustable parameters for the test scenarios
 	type testScenario struct {
-		podName                string
-		namespace              string
-		labels                 map[string]string
-		podIP                  string
-		startupDelay           time.Duration
-		preExistingPods        []string
-		preExistingPVCs        []string
-		hasDeleteError         bool
-		dialer                 Dialer
-		enableNodeProvisioning bool
-		enabledCSITests        []config.CSIType
-		fakeDynamicClient      *dynamicfake.FakeDynamicClient
+		podName                   string
+		namespace                 string
+		labels                    map[string]string
+		podIP                     string
+		startupDelay              time.Duration
+		preExistingPods           []string
+		preExistingPVCs           []string
+		preExistingStorageClasses []string
+		hasDeleteError            bool
+		dialer                    Dialer
+		enableNodeProvisioning    bool
+		enabledCSITests           []config.CSIType
+		hasCSICreateError         bool
+		hasStorageClassGetError   bool
+		fakeDynamicClient         *dynamicfake.FakeDynamicClient
 	}
 
 	// Mutator function type
@@ -154,6 +158,7 @@ func TestPodStartupChecker_check(t *testing.T) {
 			mutators: []scenarioMutator{
 				func(s *testScenario) {
 					s.enabledCSITests = []config.CSIType{config.CSITypeAzureFile}
+					s.preExistingStorageClasses = []string{azureFileStorageClassName}
 					for i := 0; i < maxSyntheticPods; i++ {
 						s.preExistingPVCs = append(s.preExistingPVCs, fmt.Sprintf("pvc%d", i))
 					}
@@ -453,6 +458,48 @@ func TestPodStartupChecker_check(t *testing.T) {
 				g.Expect(fakeDynamicClient.Actions()[2].GetVerb()).To(Equal("create"))
 			},
 		},
+		{
+			name: "error - failed to create CSI resources",
+			mutators: []scenarioMutator{
+				func(s *testScenario) {
+					s.enabledCSITests = []config.CSIType{config.CSITypeAzureBlob}
+					s.preExistingStorageClasses = []string{azureBlobStorageClassName}
+					s.hasCSICreateError = true
+				},
+			},
+			validateResult: func(g *WithT, result *checker.Result, err error, fakeDynamicClient *dynamicfake.FakeDynamicClient) {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("failed to create CSI test resources"))
+			},
+		},
+		{
+			name: "unhealthy result - storage class not found",
+			mutators: []scenarioMutator{
+				func(s *testScenario) {
+					s.enabledCSITests = []config.CSIType{config.CSITypeAzureDisk}
+					// No preExistingStorageClasses set, so the storage class won't exist
+				},
+			},
+			validateResult: func(g *WithT, result *checker.Result, err error, fakeDynamicClient *dynamicfake.FakeDynamicClient) {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(result).ToNot(BeNil())
+				g.Expect(result.Status).To(Equal(checker.StatusUnhealthy))
+				g.Expect(result.Detail.Code).To(Equal(ErrCodeStorageClassNotFound))
+			},
+		},
+		{
+			name: "error - non 404 error getting storage class",
+			mutators: []scenarioMutator{
+				func(s *testScenario) {
+					s.enabledCSITests = []config.CSIType{config.CSITypeAzureDisk}
+					s.hasStorageClassGetError = true
+				},
+			},
+			validateResult: func(g *WithT, result *checker.Result, err error, fakeDynamicClient *dynamicfake.FakeDynamicClient) {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("failed to get StorageClass"))
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -518,6 +565,24 @@ func TestPodStartupChecker_check(t *testing.T) {
 				}
 				return true, fakePod, nil
 			})
+
+			if scenario.hasCSICreateError {
+				// Simulate error when creating any CSI resources
+				client.PrependReactor("create", "persistentvolumeclaims", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.New("error creating persistentvolumeclaims")
+				})
+			}
+
+			for _, scName := range scenario.preExistingStorageClasses {
+				sc := &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: scName}}
+				client.StorageV1().StorageClasses().Create(context.Background(), sc, metav1.CreateOptions{}) //nolint:errcheck
+			}
+
+			if scenario.hasStorageClassGetError {
+				client.PrependReactor("get", "storageclasses", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.New("internal server error")
+				})
+			}
 
 			podStartupChecker := &PodStartupChecker{
 				name: checkerName,

--- a/pkg/checker/podstartup/storage.go
+++ b/pkg/checker/podstartup/storage.go
@@ -102,6 +102,30 @@ func (c *PodStartupChecker) azureBlobPVC(timestampStr string) *corev1.Persistent
 	}
 }
 
+func storageClassForCSIType(csiType config.CSIType) string {
+	switch csiType {
+	case config.CSITypeAzureDisk:
+		return azureDiskStorageClassName
+	case config.CSITypeAzureFile:
+		return azureFileStorageClassName
+	case config.CSITypeAzureBlob:
+		return azureBlobStorageClassName
+	default:
+		return ""
+	}
+}
+
+func (c *PodStartupChecker) validateStorageClasses(ctx context.Context) error {
+	for _, csiType := range c.config.EnabledCSIs {
+		scName := storageClassForCSIType(csiType)
+		_, err := c.k8sClientset.StorageV1().StorageClasses().Get(ctx, scName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get StorageClass %q for CSI type %q: %w", scName, csiType, err)
+		}
+	}
+	return nil
+}
+
 func (c *PodStartupChecker) createCSIResources(ctx context.Context, timestampStr string) error {
 	for _, csiType := range c.config.EnabledCSIs {
 		switch csiType {

--- a/pkg/checker/podstartup/storage_test.go
+++ b/pkg/checker/podstartup/storage_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/cluster-health-monitor/pkg/config"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -389,6 +390,82 @@ func TestCheckPVCQuota(t *testing.T) {
 			} else {
 				g.Expect(err).NotTo(HaveOccurred())
 			}
+		})
+	}
+}
+
+func TestValidateStorageClasses(t *testing.T) {
+	testCases := []struct {
+		name        string
+		enabledCSIs []config.CSIType
+		k8sClient   *k8sfake.Clientset
+		validateRes func(g *WithT, err error)
+	}{
+		{
+			name:        "passes - no CSI enabled",
+			enabledCSIs: []config.CSIType{},
+			k8sClient:   k8sfake.NewClientset(),
+			validateRes: func(g *WithT, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+			},
+		},
+		{
+			name:        "passes - all storage classes exist",
+			enabledCSIs: []config.CSIType{config.CSITypeAzureDisk, config.CSITypeAzureFile, config.CSITypeAzureBlob},
+			k8sClient: k8sfake.NewClientset(
+				&storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: azureDiskStorageClassName}},
+				&storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: azureFileStorageClassName}},
+				&storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: azureBlobStorageClassName}},
+			),
+			validateRes: func(g *WithT, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+			},
+		},
+		{
+			name:        "error - storage class not found",
+			enabledCSIs: []config.CSIType{config.CSITypeAzureDisk, config.CSITypeAzureFile},
+			k8sClient: k8sfake.NewClientset(
+				&storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: azureDiskStorageClassName}},
+				// Azure File storage class is missing to trigger not found error
+			),
+			validateRes: func(g *WithT, err error) {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("failed to get StorageClass"))
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			},
+		},
+		{
+			name:        "error - non 404 error getting storage class",
+			enabledCSIs: []config.CSIType{config.CSITypeAzureBlob},
+			k8sClient: func() *k8sfake.Clientset {
+				client := k8sfake.NewClientset()
+				client.PrependReactor("get", "storageclasses", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, errors.New("connection refused")
+				})
+				return client
+			}(),
+			validateRes: func(g *WithT, err error) {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("failed to get StorageClass"))
+				g.Expect(apierrors.IsNotFound(err)).To(BeFalse())
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			chk := &PodStartupChecker{
+				config: &config.PodStartupConfig{
+					EnabledCSIs: tc.enabledCSIs,
+				},
+				k8sClientset: tc.k8sClient,
+			}
+
+			err := chk.validateStorageClasses(context.Background())
+			tc.validateRes(g, err)
 		})
 	}
 }


### PR DESCRIPTION
The CSI checker will now emit a clear error code if a storage class is missing. Without this error code, this will surface as a timeout error in the metrics because the PVC will get stuck trying to provision the storage class.