### PR TITLE
Update e2e tests to remain compatible with aks automatic

### DIFF
--- a/.github/workflows/aks-e2e.yaml
+++ b/.github/workflows/aks-e2e.yaml
@@ -182,6 +182,7 @@ jobs:
               --location "${{ needs.validate_region.outputs.region }}" \
               --subscription "$SUBSCRIPTION_ID" \
               --sku "${{ needs.validate_sku.outputs.sku }}" \
+              --tags "enable-cluster-health-monitor=false" \
               --no-ssh-key
 
   deploy_kubernetes_resources:

--- a/manifests/base/cluster-health-monitor/rbac.yaml
+++ b/manifests/base/cluster-health-monitor/rbac.yaml
@@ -12,13 +12,13 @@ metadata:
   name: cluster-health-monitor-kubedns-reader
   namespace: kube-system
 rules:
-  - apiGroups: [ "" ]
-    resources: [ "services" ]
-    resourceNames: [ "kube-dns" ]
-    verbs: [ "get" ]
-  - apiGroups: [ "discovery.k8s.io" ]
-    resources: [ "endpointslices" ]
-    verbs: [ "list" ]
+  - apiGroups: [""]
+    resources: ["services"]
+    resourceNames: ["kube-dns"]
+    verbs: ["get"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -41,12 +41,15 @@ metadata:
   name: cluster-health-monitor-synth-pod-manager
   namespace: kube-system
 rules:
-  - apiGroups: [ "" ]
-    resources: [ "pods" ]
-    verbs: [ "get", "create", "list", "delete" ]
-  - apiGroups: [ "" ]
-    resources: [ "events" ]
-    verbs: [ "get", "list" ]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "create", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "create", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -69,9 +72,9 @@ metadata:
   name: cluster-health-monitor-configmap-manager
   namespace: kube-system
 rules:
-  - apiGroups: [ "" ]
-    resources: [ "configmaps" ]
-    verbs: [ "get", "create", "list", "delete" ]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "list", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -88,7 +91,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 # Role for managing pods in default namespace. At time of writing, this is used by the azure policy checker. This role exists because the
-# default configuration of azure-policy is not evaluated in the kube-system namespace. However, pod creation requests are rejected by the 
+# default configuration of azure-policy is not evaluated in the kube-system namespace. However, pod creation requests are rejected by the
 # API server before azure policy can be evaluated if this permission is not present. All modifying requests in the default namespace should
 # be dry-run only.
 apiVersion: rbac.authorization.k8s.io/v1
@@ -97,9 +100,9 @@ metadata:
   name: cluster-health-monitor-default-pod-manager
   namespace: default
 rules:
-  - apiGroups: [ "" ]
-    resources: [ "pods" ]
-    verbs: [ "get", "create", "list", "delete" ]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "create", "list", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -121,9 +124,9 @@ kind: ClusterRole
 metadata:
   name: cluster-health-monitor-metrics-server-reader
 rules:
-  - apiGroups: [ "metrics.k8s.io" ]
-    resources: [ "nodes", "pods" ]
-    verbs: [ "get", "list" ]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["nodes", "pods"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -144,24 +147,24 @@ kind: ClusterRole
 metadata:
   name: cluster-health-monitor-karpenter-admin
 rules:
-  - apiGroups: [ "apiextensions.k8s.io" ]
-    resources: [ "customresourcedefinitions" ]
-    resourceNames: [ "nodepools.karpenter.sh" ]
-    verbs: [ "get", "list" ]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    resourceNames: ["nodepools.karpenter.sh"]
+    verbs: ["get", "list"]
 
   # Core Karpenter v1beta1 APIs
-  - apiGroups: [ "karpenter.sh" ]
+  - apiGroups: ["karpenter.sh"]
     resources:
       - nodepools
       - nodepools/status
       - nodeclaims
       - nodeclaims/status
-    verbs: [ "get", "list", "create", "delete" ]
+    verbs: ["get", "list", "create", "delete"]
 
   # Provider-specific NodeClass
-  - apiGroups: [ "karpenter.azure.com" ]
-    resources: [ "aksnodeclasses" ]
-    verbs: [ "get", "list", "watch" ]
+  - apiGroups: ["karpenter.azure.com"]
+    resources: ["aksnodeclasses"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/test/e2e/checknodehealth_test.go
+++ b/test/e2e/checknodehealth_test.go
@@ -292,9 +292,14 @@ var _ = Describe("CheckNodeHealth Controller", Ordered, ContinueOnFailure, func(
 	It("should set NodeHealthy condition on node when health check fails", func() {
 		By("Creating a fake Node object for the test")
 		fakeNodeName := fmt.Sprintf("fake-node-condition-test-%d", time.Now().Unix())
+		// Use a finalizer to prevent the cloud-node-lifecycle-controller from deleting this fake node before the checknodehealth controller
+		// can set the NodeHealthy condition on it. Otherwise the following may occur:
+		// 15m Normal DeletingNode Node/fake-node-condition-test-1775085210 Deleting node fake-node-condition-test-1775085210 because it does not exist in the cloud provider
+		fakeNodeFinalizer := "e2e-test/fake-node-protection"
 		fakeNode := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: fakeNodeName,
+				Name:       fakeNodeName,
+				Finalizers: []string{fakeNodeFinalizer},
 			},
 		}
 		err := k8sClient.Create(ctx, fakeNode)
@@ -303,7 +308,17 @@ var _ = Describe("CheckNodeHealth Controller", Ordered, ContinueOnFailure, func(
 
 		defer func() {
 			By("Cleaning up fake Node")
-			if err := k8sClient.Delete(ctx, fakeNode); err != nil {
+			node := &corev1.Node{}
+			if err := k8sClient.Get(ctx, client.ObjectKey{Name: fakeNodeName}, node); err != nil {
+				GinkgoWriter.Printf("Warning: Failed to get fake Node %s for cleanup: %v\n", fakeNodeName, err)
+				return
+			}
+			// Remove finalizer so the node can be deleted
+			node.Finalizers = nil
+			if err := k8sClient.Update(ctx, node); err != nil {
+				GinkgoWriter.Printf("Warning: Failed to remove finalizer from %s: %v\n", fakeNodeName, err)
+			}
+			if err := k8sClient.Delete(ctx, node); client.IgnoreNotFound(err) != nil {
 				GinkgoWriter.Printf("Warning: Failed to delete fake Node %s: %v\n", fakeNodeName, err)
 			}
 		}()


### PR DESCRIPTION
Applies the following to make the e2e tests compatible with aks automatic clusters again:

1) The manifests used for testing share resource names and types with the aks managed cluster-health-monitor that is now recently enabled by default. Because of that, the managed version ends up overwriting the e2e test resources with its own values. This causes the e2e tests to break, for example, checker configurations get overwritten. This PR disables the AKS-managed cluster-health-monitor in e2e aks test clusters so the test manifests aren’t modified during runs.

2) Update the rbac in the manifest so that podstartup checker can do pvc operations. When I checked the logs, the garbage collect was failing although the test still passed.
`"Failed to garbage collect old synthetic pods" err="failed to garbage collect outdated persistent volume claims: failed to list persistent volume claims: persistentvolumeclaims is forbidden`

3. AKS was detecting the fake nodes from the check node health e2e tests did not exist in the cloud provider and was automatically deleting them before the test could complete. This was causing scenarios that had to modify/validate the healthy condition on the node to fail. Added a finalizer to the node health check scenario to prevent this from occurring. 
`15m                 Normal    DeletingNode              Node/fake-node-condition-test-1775085210                             Deleting node fake-node-condition-test-1775085210 because it does not exist in the cloud provider`