### PR TITLE
Remove explicit `GOEXPERIMENT=systemcrypto`

### DIFF
--- a/docker/cluster-health-monitor.Dockerfile
+++ b/docker/cluster-health-monitor.Dockerfile
@@ -15,9 +15,9 @@ COPY pkg/ pkg/
 COPY apis/ apis/
 
 # Build
-RUN CGO_ENABLED=1 GOEXPERIMENT=systemcrypto go build -o clusterhealthmonitor cmd/clusterhealthmonitor/main.go
-RUN CGO_ENABLED=1 GOEXPERIMENT=systemcrypto go build -o controller cmd/controller/checknodehealth/main.go
-RUN CGO_ENABLED=1 GOEXPERIMENT=systemcrypto go build -o nodechecker cmd/nodechecker/main.go
+RUN CGO_ENABLED=1 go build -o clusterhealthmonitor cmd/clusterhealthmonitor/main.go
+RUN CGO_ENABLED=1 go build -o controller cmd/controller/checknodehealth/main.go
+RUN CGO_ENABLED=1 go build -o nodechecker cmd/nodechecker/main.go
 
 # Patch the distroless base image with updated openssl packages
 FROM mcr.microsoft.com/azurelinux/distroless/base:3.0 AS distroless-base


### PR DESCRIPTION
Microsoft build of Go maintainer here. SystemCrypto is enabled by default since Go 1.25, no need to set it manually (see [docs](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/MigrationGuide.md#enable-systemcrypto)). That experiment will most likely disappear in Go 1.27, so removing it now will safe you from a build error once upgrading to Go 1.27.