### PR TITLE
Update ci to use microsoft go

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Mark workspace as safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install Docker CLI
-        run: tdnf install -y moby-cli
+        run: apt-get update && apt-get install -y docker.io
       - uses: azure/setup-kubectl@v4
       - name: Install kind
         run: go install sigs.k8s.io/kind@v0.29.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/oss/go/microsoft/golang:1.26.2
+      options: --network host
       volumes:
         - /var/run/docker.sock:/var/run/docker.sock
     needs: [test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           docker cp msgo:/usr/local/go "$HOME/microsoft-go"
           docker rm msgo
           echo "$HOME/microsoft-go/bin" >> "$GITHUB_PATH"
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
       - uses: azure/setup-kubectl@v4
       - name: Install kind
         run: go install sigs.k8s.io/kind@v0.29.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,10 @@ jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/oss/go/microsoft/golang:1.26.2
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
@@ -30,11 +29,10 @@ jobs:
   test:
     name: Unit Tests
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/oss/go/microsoft/golang:1.26.2
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
       - name: Download dependencies
         run: go mod download
       - name: Run tests
@@ -43,12 +41,13 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/oss/go/microsoft/golang:1.26.2
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
     needs: [test]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
       - uses: azure/setup-kubectl@v4
       - name: Install kind
         run: go install sigs.k8s.io/kind@v0.29.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,18 +41,16 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    container:
-      image: mcr.microsoft.com/oss/go/microsoft/golang:1.26.2
-      options: --network host
-      volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
     needs: [test]
     steps:
       - uses: actions/checkout@v4
-      - name: Mark workspace as safe for git
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-      - name: Install Docker CLI
-        run: apt-get update && apt-get install -y docker.io
+      - name: Install Microsoft Go
+        run: |
+          docker pull mcr.microsoft.com/oss/go/microsoft/golang:1.26.2
+          docker create --name msgo mcr.microsoft.com/oss/go/microsoft/golang:1.26.2
+          docker cp msgo:/usr/local/go "$HOME/microsoft-go"
+          docker rm msgo
+          echo "$HOME/microsoft-go/bin" >> "$GITHUB_PATH"
       - uses: azure/setup-kubectl@v4
       - name: Install kind
         run: go install sigs.k8s.io/kind@v0.29.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
     needs: [test]
     steps:
       - uses: actions/checkout@v4
+      - name: Mark workspace as safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: azure/setup-kubectl@v4
       - name: Install kind
         run: go install sigs.k8s.io/kind@v0.29.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Mark workspace as safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Install Docker CLI
+        run: tdnf install -y moby-cli
       - uses: azure/setup-kubectl@v4
       - name: Install kind
         run: go install sigs.k8s.io/kind@v0.29.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Download dependencies
         run: go mod download
       - name: Run tests
-        run: go test -buildvcs=false --race $(go list ./... | grep -v /e2e)
+        run: go test -buildvcs=false --race $(go list -buildvcs=false ./... | grep -v /e2e)
 
   e2e:
     name: E2E Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Download dependencies
         run: go mod download
       - name: Run tests
-        run: go test --race $(go list ./... | grep -v /e2e)
+        run: go test -buildvcs=false --race $(go list ./... | grep -v /e2e)
 
   e2e:
     name: E2E Tests


### PR DESCRIPTION
As a followup for https://github.com/Azure/cluster-health-monitor/pull/251, the doc referenced also mentions that ci tests should be using same Microsoft go build to keep consistency: https://github.com/microsoft/go/blob/microsoft/main/eng/doc/MigrationGuide.md#testing