### PR TITLE
Wait for nodes to be ready before boot health check

### DIFF
--- a/cmd/controller/checknodehealth/main.go
+++ b/cmd/controller/checknodehealth/main.go
@@ -117,7 +117,9 @@ func main() {
 	}
 
 	// When node reboot detection is enabled, cache Node objects with a transformer
-	// that strips most fields to minimize memory usage. Only metadata and bootID are retained.
+	// that strips most fields to minimize memory usage. Only metadata, bootID, and
+	// conditions are retained — conditions are needed so the reboot reconciler can
+	// defer creating CheckNodeHealth CRs until the node reports Ready.
 	if enableNodeRebootCheck {
 		cacheByObject[&corev1.Node{}] = cache.ByObject{
 			Transform: func(obj interface{}) (interface{}, error) {
@@ -129,6 +131,7 @@ func main() {
 					NodeInfo: corev1.NodeSystemInfo{
 						BootID: node.Status.NodeInfo.BootID,
 					},
+					Conditions: node.Status.Conditions,
 				}
 				node.Spec = corev1.NodeSpec{}
 				return node, nil

--- a/pkg/controller/node/controller.go
+++ b/pkg/controller/node/controller.go
@@ -47,6 +47,16 @@ const (
 	// have been created. Returning a short RequeueAfter keeps the worker free
 	// to reconcile other nodes instead of blocking inside Reconcile.
 	NodeReadyRequeueInterval = 30 * time.Second
+
+	// NodeReadyMaxWait bounds how long the controller will keep requeueing a
+	// node that remains not Ready before giving up on the proactive retry
+	// loop. Once exceeded, reconcile returns without requeueing and without
+	// persisting the bootID, so a later Ready=True transition (delivered via
+	// the watch) can still produce a CheckNodeHealth for the current boot.
+	// Without this bound a node stuck in Ready=False would be requeued
+	// forever. The value is aligned with Karpenter's Node Auto Repair unready
+	// timeout (10m); the in-house Remediator uses 5m for the same condition.
+	NodeReadyMaxWait = 10 * time.Minute
 )
 
 // NodeRebootReconciler watches Node objects and creates CheckNodeHealth CRs
@@ -103,6 +113,11 @@ func (r *NodeRebootReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				return ctrl.Result{}, err
 			}
 			if !created {
+				if notReadyExceeds(node, NodeReadyMaxWait) {
+					// Node has been not Ready for too long; stop the requeue loop.
+					klog.InfoS("Node not Ready past max wait,", "node", node.Name, "bootID", currentBootID, "maxWait", NodeReadyMaxWait)
+					return ctrl.Result{}, nil
+				}
 				// Node not Ready yet; requeue without persisting the bootID so we
 				// re-evaluate on the next reconcile and don't block this worker.
 				return ctrl.Result{RequeueAfter: NodeReadyRequeueInterval}, nil
@@ -125,6 +140,11 @@ func (r *NodeRebootReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 	if !created {
+		if notReadyExceeds(node, NodeReadyMaxWait) {
+			// Node has been not Ready for too long; stop the requeue loop.
+			klog.InfoS("Node not Ready past max wait,", "node", node.Name, "bootID", currentBootID, "maxWait", NodeReadyMaxWait)
+			return ctrl.Result{}, nil
+		}
 		// Node not Ready yet; requeue without persisting the new bootID so the
 		// reboot remains detectable on the next reconcile.
 		return ctrl.Result{RequeueAfter: NodeReadyRequeueInterval}, nil
@@ -180,6 +200,24 @@ func isNodeReady(node *corev1.Node) bool {
 		}
 	}
 	return false
+}
+
+// notReadyExceeds reports whether the node's Ready condition is not True and
+// its LastTransitionTime is older than the given duration. If the Ready
+// condition is missing, the node's CreationTimestamp is used as the reference
+// point so freshly observed nodes without a Ready condition are not
+// immediately considered to have exceeded the wait.
+func notReadyExceeds(node *corev1.Node, d time.Duration) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type != corev1.NodeReady {
+			continue
+		}
+		if c.Status == corev1.ConditionTrue {
+			return false
+		}
+		return time.Since(c.LastTransitionTime.Time) > d
+	}
+	return time.Since(node.CreationTimestamp.Time) > d
 }
 
 // removeStaleNodeCondition removes the NodeHealthy condition from the node

--- a/pkg/controller/node/controller.go
+++ b/pkg/controller/node/controller.go
@@ -43,6 +43,21 @@ const (
 	NodeConditionTTL = 30 * time.Minute
 )
 
+// Tunable wait parameters for the Ready check inside createCheckNodeHealth.
+// These are var (not const) so tests can shorten them.
+var (
+	// NodeReadyPollInterval is how often to re-check a node's Ready condition
+	// while waiting for it to become Ready before creating a CheckNodeHealth.
+	NodeReadyPollInterval = 5 * time.Second
+
+	// NodeReadyWaitTimeout is the maximum time to wait for a node to become
+	// Ready before giving up on creating a CheckNodeHealth for the current
+	// reconcile. The reconciler will retry on the next observation.
+	// Set it as 5 minute because node being not ready for over 5 min should have been
+	// remediated by AKS.
+	NodeReadyWaitTimeout = 5 * time.Minute
+)
+
 // NodeRebootReconciler watches Node objects and creates CheckNodeHealth CRs
 // when a node reboot is detected via a change in bootID.
 type NodeRebootReconciler struct {
@@ -115,10 +130,19 @@ func (r *NodeRebootReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	return ctrl.Result{RequeueAfter: NodeConditionTTL}, r.updateBootIDAnnotation(ctx, node, currentBootID)
 }
 
-// createCheckNodeHealth creates a CheckNodeHealth CR with a deterministic name.
+// createCheckNodeHealth waits until the node reports Ready=True, then creates
+// a CheckNodeHealth CR with a deterministic name. Running the health checks
+// against a node that has not finished initializing (e.g., still booting after
+// a reboot) would produce spurious failures, so this function polls the node's
+// status until it is Ready before creating the CR.
+//
 // If a CR with the same name already exists (e.g., from a duplicate reconcile),
 // the AlreadyExists error is safely ignored.
 func (r *NodeRebootReconciler) createCheckNodeHealth(ctx context.Context, node *corev1.Node, bootID string) error {
+	if err := r.waitForNodeReady(ctx, node); err != nil {
+		return fmt.Errorf("node %s did not become Ready: %w", node.Name, err)
+	}
+
 	crName := GenerateCNHName(node.Name, bootID)
 	cnh := &chmv1alpha1.CheckNodeHealth{
 		ObjectMeta: metav1.ObjectMeta{
@@ -140,6 +164,48 @@ func (r *NodeRebootReconciler) createCheckNodeHealth(ctx context.Context, node *
 	}
 	klog.InfoS("Created CheckNodeHealth for rebooted node", "name", crName, "node", node.Name, "bootID", bootID)
 	return nil
+}
+
+// waitForNodeReady blocks until the given node reports Ready=True, the context
+// is cancelled, or NodeReadyWaitTimeout elapses. The node argument is refreshed
+// in place with the latest observed state.
+func (r *NodeRebootReconciler) waitForNodeReady(ctx context.Context, node *corev1.Node) error {
+	if isNodeReady(node) {
+		return nil
+	}
+
+	klog.InfoS("Waiting for node to become Ready before creating CheckNodeHealth", "node", node.Name)
+
+	waitCtx, cancel := context.WithTimeout(ctx, NodeReadyWaitTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(NodeReadyPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-waitCtx.Done():
+			return waitCtx.Err()
+		case <-ticker.C:
+			if err := r.Get(waitCtx, client.ObjectKeyFromObject(node), node); err != nil {
+				return fmt.Errorf("failed to refresh node %s: %w", node.Name, err)
+			}
+			if isNodeReady(node) {
+				klog.InfoS("Node is now Ready", "node", node.Name)
+				return nil
+			}
+		}
+	}
+}
+
+// isNodeReady reports whether the node has a Ready condition with status True.
+func isNodeReady(node *corev1.Node) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }
 
 // removeStaleNodeCondition removes the NodeHealthy condition from the node

--- a/pkg/controller/node/controller.go
+++ b/pkg/controller/node/controller.go
@@ -41,21 +41,12 @@ const (
 	// it is garbage collected. Stale conditions are removed to avoid leaving
 	// outdated health signals on nodes after the check results expire.
 	NodeConditionTTL = 30 * time.Minute
-)
 
-// Tunable wait parameters for the Ready check inside createCheckNodeHealth.
-// These are var (not const) so tests can shorten them.
-var (
-	// NodeReadyPollInterval is how often to re-check a node's Ready condition
-	// while waiting for it to become Ready before creating a CheckNodeHealth.
-	NodeReadyPollInterval = 5 * time.Second
-
-	// NodeReadyWaitTimeout is the maximum time to wait for a node to become
-	// Ready before giving up on creating a CheckNodeHealth for the current
-	// reconcile. The reconciler will retry on the next observation.
-	// Set it as 5 minute because node being not ready for over 5 min should have been
-	// remediated by AKS.
-	NodeReadyWaitTimeout = 5 * time.Minute
+	// NodeReadyRequeueInterval is how long to wait before re-checking a node
+	// that was observed as not Ready when a CheckNodeHealth would otherwise
+	// have been created. Returning a short RequeueAfter keeps the worker free
+	// to reconcile other nodes instead of blocking inside Reconcile.
+	NodeReadyRequeueInterval = 30 * time.Second
 )
 
 // NodeRebootReconciler watches Node objects and creates CheckNodeHealth CRs
@@ -107,8 +98,14 @@ func (r *NodeRebootReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if lastBootID == "" {
 		if time.Since(node.CreationTimestamp.Time) < NewNodeThreshold {
 			klog.InfoS("New node detected, creating health check", "node", node.Name, "bootID", currentBootID)
-			if err := r.createCheckNodeHealth(ctx, node, currentBootID); err != nil {
+			created, err := r.createCheckNodeHealth(ctx, node, currentBootID)
+			if err != nil {
 				return ctrl.Result{}, err
+			}
+			if !created {
+				// Node not Ready yet; requeue without persisting the bootID so we
+				// re-evaluate on the next reconcile and don't block this worker.
+				return ctrl.Result{RequeueAfter: NodeReadyRequeueInterval}, nil
 			}
 		} else {
 			klog.InfoS("Initializing bootID annotation for existing node", "node", node.Name, "bootID", currentBootID)
@@ -123,24 +120,33 @@ func (r *NodeRebootReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	// Reboot detected.
 	klog.InfoS("Node reboot detected", "node", node.Name, "oldBootID", lastBootID, "newBootID", currentBootID)
-	if err := r.createCheckNodeHealth(ctx, node, currentBootID); err != nil {
+	created, err := r.createCheckNodeHealth(ctx, node, currentBootID)
+	if err != nil {
 		return ctrl.Result{}, err
+	}
+	if !created {
+		// Node not Ready yet; requeue without persisting the new bootID so the
+		// reboot remains detectable on the next reconcile.
+		return ctrl.Result{RequeueAfter: NodeReadyRequeueInterval}, nil
 	}
 
 	return ctrl.Result{RequeueAfter: NodeConditionTTL}, r.updateBootIDAnnotation(ctx, node, currentBootID)
 }
 
-// createCheckNodeHealth waits until the node reports Ready=True, then creates
-// a CheckNodeHealth CR with a deterministic name. Running the health checks
-// against a node that has not finished initializing (e.g., still booting after
-// a reboot) would produce spurious failures, so this function polls the node's
-// status until it is Ready before creating the CR.
+// createCheckNodeHealth creates a CheckNodeHealth CR with a deterministic
+// name, but only if the node currently reports Ready=True. Running the health
+// checks against a node that has not finished initializing (e.g., still
+// booting after a reboot) would produce spurious failures, so the caller
+// should requeue and retry when this returns (false, nil).
 //
-// If a CR with the same name already exists (e.g., from a duplicate reconcile),
-// the AlreadyExists error is safely ignored.
-func (r *NodeRebootReconciler) createCheckNodeHealth(ctx context.Context, node *corev1.Node, bootID string) error {
-	if err := r.waitForNodeReady(ctx, node); err != nil {
-		return fmt.Errorf("node %s did not become Ready: %w", node.Name, err)
+// Returns (true, nil) if the CR was created (or already existed). Returns
+// (false, nil) if the node is not Ready yet and no CR was created. If a CR
+// with the same name already exists (e.g., from a duplicate reconcile), the
+// AlreadyExists error is safely ignored.
+func (r *NodeRebootReconciler) createCheckNodeHealth(ctx context.Context, node *corev1.Node, bootID string) (bool, error) {
+	if !isNodeReady(node) {
+		klog.InfoS("Node is not Ready yet, deferring CheckNodeHealth creation", "node", node.Name, "bootID", bootID)
+		return false, nil
 	}
 
 	crName := GenerateCNHName(node.Name, bootID)
@@ -158,44 +164,12 @@ func (r *NodeRebootReconciler) createCheckNodeHealth(ctx context.Context, node *
 	if err := r.Create(ctx, cnh); err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			klog.V(1).InfoS("CheckNodeHealth already exists for this boot", "name", crName, "node", node.Name)
-			return nil
+			return true, nil
 		}
-		return fmt.Errorf("failed to create CheckNodeHealth for node %s: %w", node.Name, err)
+		return false, fmt.Errorf("failed to create CheckNodeHealth for node %s: %w", node.Name, err)
 	}
 	klog.InfoS("Created CheckNodeHealth for rebooted node", "name", crName, "node", node.Name, "bootID", bootID)
-	return nil
-}
-
-// waitForNodeReady blocks until the given node reports Ready=True, the context
-// is cancelled, or NodeReadyWaitTimeout elapses. The node argument is refreshed
-// in place with the latest observed state.
-func (r *NodeRebootReconciler) waitForNodeReady(ctx context.Context, node *corev1.Node) error {
-	if isNodeReady(node) {
-		return nil
-	}
-
-	klog.InfoS("Waiting for node to become Ready before creating CheckNodeHealth", "node", node.Name)
-
-	waitCtx, cancel := context.WithTimeout(ctx, NodeReadyWaitTimeout)
-	defer cancel()
-
-	ticker := time.NewTicker(NodeReadyPollInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-waitCtx.Done():
-			return waitCtx.Err()
-		case <-ticker.C:
-			if err := r.Get(waitCtx, client.ObjectKeyFromObject(node), node); err != nil {
-				return fmt.Errorf("failed to refresh node %s: %w", node.Name, err)
-			}
-			if isNodeReady(node) {
-				klog.InfoS("Node is now Ready", "node", node.Name)
-				return nil
-			}
-		}
-	}
+	return true, nil
 }
 
 // isNodeReady reports whether the node has a Ready condition with status True.

--- a/pkg/controller/node/controller_test.go
+++ b/pkg/controller/node/controller_test.go
@@ -138,6 +138,22 @@ func TestNodeRebootReconcile(t *testing.T) {
 			expectBootAnno: "",
 			expectRequeue:  0,
 		},
+		{
+			name:           "new node not Ready yet — no CNH, annotation not set, requeues",
+			node:           newNotReadyNode("node-1", "boot-aaa", nil, time.Now()),
+			expectCNH:      false,
+			expectBootAnno: "",
+			expectRequeue:  NodeReadyRequeueInterval,
+		},
+		{
+			name: "reboot detected but node not Ready yet — no CNH, annotation unchanged, requeues",
+			node: newNotReadyNode("node-1", "boot-bbb", map[string]string{
+				AnnotationLastBootID: "boot-aaa",
+			}, time.Time{}),
+			expectCNH:      false,
+			expectBootAnno: "boot-aaa",
+			expectRequeue:  NodeReadyRequeueInterval,
+		},
 	}
 
 	for _, tc := range tests {
@@ -353,23 +369,17 @@ func TestRemoveStaleNodeCondition(t *testing.T) {
 	}
 }
 
-func TestCreateCheckNodeHealthWaitsForReady(t *testing.T) {
-	// Shorten wait/poll to keep the test fast.
-	origPoll, origTimeout := NodeReadyPollInterval, NodeReadyWaitTimeout
-	NodeReadyPollInterval = 10 * time.Millisecond
-	NodeReadyWaitTimeout = 50 * time.Millisecond
-	t.Cleanup(func() {
-		NodeReadyPollInterval = origPoll
-		NodeReadyWaitTimeout = origTimeout
-	})
-
-	t.Run("not Ready within timeout returns error and creates no CR", func(t *testing.T) {
+func TestCreateCheckNodeHealthSkipsWhenNotReady(t *testing.T) {
+	t.Run("not Ready returns (false, nil) and creates no CR", func(t *testing.T) {
 		node := newNotReadyNode("node-1", "boot-aaa", nil, time.Now())
 		r, fc := setupRebootTest(node)
 
-		err := r.createCheckNodeHealth(context.Background(), node, "boot-aaa")
-		if err == nil {
-			t.Fatal("expected error when node never becomes Ready")
+		created, err := r.createCheckNodeHealth(context.Background(), node, "boot-aaa")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if created {
+			t.Fatal("expected created=false when node is not Ready")
 		}
 
 		cnh := &chmv1alpha1.CheckNodeHealth{}
@@ -379,28 +389,16 @@ func TestCreateCheckNodeHealthWaitsForReady(t *testing.T) {
 		}
 	})
 
-	t.Run("becomes Ready before timeout creates CR", func(t *testing.T) {
-		node := newNotReadyNode("node-1", "boot-aaa", nil, time.Now())
+	t.Run("Ready returns (true, nil) and creates CR", func(t *testing.T) {
+		node := newNodeWithCreationTime("node-1", "boot-aaa", nil, time.Now())
 		r, fc := setupRebootTest(node)
-		nodeKey := client.ObjectKey{Name: node.Name}
 
-		// Flip the node to Ready shortly after the call begins. Use a separate
-		// Node value to avoid racing with waitForNodeReady, which writes into
-		// the node passed to createCheckNodeHealth.
-		go func() {
-			time.Sleep(15 * time.Millisecond)
-			updated := &corev1.Node{}
-			if err := fc.Get(context.Background(), nodeKey, updated); err != nil {
-				return
-			}
-			updated.Status.Conditions = []corev1.NodeCondition{
-				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
-			}
-			_ = fc.Status().Update(context.Background(), updated)
-		}()
-
-		if err := r.createCheckNodeHealth(context.Background(), node, "boot-aaa"); err != nil {
+		created, err := r.createCheckNodeHealth(context.Background(), node, "boot-aaa")
+		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+		if !created {
+			t.Fatal("expected created=true when node is Ready")
 		}
 
 		cnh := &chmv1alpha1.CheckNodeHealth{}

--- a/pkg/controller/node/controller_test.go
+++ b/pkg/controller/node/controller_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -56,8 +57,20 @@ func newNodeWithCreationTime(name, bootID string, annotations map[string]string,
 			NodeInfo: corev1.NodeSystemInfo{
 				BootID: bootID,
 			},
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+			},
 		},
 	}
+}
+
+// newNotReadyNode is like newNode but the Ready condition is False.
+func newNotReadyNode(name, bootID string, annotations map[string]string, creationTime time.Time) *corev1.Node {
+	n := newNodeWithCreationTime(name, bootID, annotations, creationTime)
+	n.Status.Conditions = []corev1.NodeCondition{
+		{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+	}
+	return n
 }
 
 func TestNodeRebootReconcile(t *testing.T) {
@@ -338,4 +351,58 @@ func TestRemoveStaleNodeCondition(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCreateCheckNodeHealthWaitsForReady(t *testing.T) {
+	// Shorten wait/poll to keep the test fast.
+	origPoll, origTimeout := NodeReadyPollInterval, NodeReadyWaitTimeout
+	NodeReadyPollInterval = 10 * time.Millisecond
+	NodeReadyWaitTimeout = 50 * time.Millisecond
+	t.Cleanup(func() {
+		NodeReadyPollInterval = origPoll
+		NodeReadyWaitTimeout = origTimeout
+	})
+
+	t.Run("not Ready within timeout returns error and creates no CR", func(t *testing.T) {
+		node := newNotReadyNode("node-1", "boot-aaa", nil, time.Now())
+		r, fc := setupRebootTest(node)
+
+		err := r.createCheckNodeHealth(context.Background(), node, "boot-aaa")
+		if err == nil {
+			t.Fatal("expected error when node never becomes Ready")
+		}
+
+		cnh := &chmv1alpha1.CheckNodeHealth{}
+		gotErr := fc.Get(context.Background(), client.ObjectKey{Name: GenerateCNHName("node-1", "boot-aaa")}, cnh)
+		if !apierrors.IsNotFound(gotErr) {
+			t.Errorf("expected NotFound error for CheckNodeHealth, got %v", gotErr)
+		}
+	})
+
+	t.Run("becomes Ready before timeout creates CR", func(t *testing.T) {
+		node := newNotReadyNode("node-1", "boot-aaa", nil, time.Now())
+		r, fc := setupRebootTest(node)
+
+		// Flip the node to Ready shortly after the call begins.
+		go func() {
+			time.Sleep(15 * time.Millisecond)
+			updated := &corev1.Node{}
+			if err := fc.Get(context.Background(), client.ObjectKeyFromObject(node), updated); err != nil {
+				return
+			}
+			updated.Status.Conditions = []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+			}
+			_ = fc.Status().Update(context.Background(), updated)
+		}()
+
+		if err := r.createCheckNodeHealth(context.Background(), node, "boot-aaa"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		cnh := &chmv1alpha1.CheckNodeHealth{}
+		if err := fc.Get(context.Background(), client.ObjectKey{Name: GenerateCNHName("node-1", "boot-aaa")}, cnh); err != nil {
+			t.Errorf("expected CheckNodeHealth to be created: %v", err)
+		}
+	})
 }

--- a/pkg/controller/node/controller_test.go
+++ b/pkg/controller/node/controller_test.go
@@ -382,12 +382,15 @@ func TestCreateCheckNodeHealthWaitsForReady(t *testing.T) {
 	t.Run("becomes Ready before timeout creates CR", func(t *testing.T) {
 		node := newNotReadyNode("node-1", "boot-aaa", nil, time.Now())
 		r, fc := setupRebootTest(node)
+		nodeKey := client.ObjectKey{Name: node.Name}
 
-		// Flip the node to Ready shortly after the call begins.
+		// Flip the node to Ready shortly after the call begins. Use a separate
+		// Node value to avoid racing with waitForNodeReady, which writes into
+		// the node passed to createCheckNodeHealth.
 		go func() {
 			time.Sleep(15 * time.Millisecond)
 			updated := &corev1.Node{}
-			if err := fc.Get(context.Background(), client.ObjectKeyFromObject(node), updated); err != nil {
+			if err := fc.Get(context.Background(), nodeKey, updated); err != nil {
 				return
 			}
 			updated.Status.Conditions = []corev1.NodeCondition{

--- a/pkg/controller/node/controller_test.go
+++ b/pkg/controller/node/controller_test.go
@@ -64,11 +64,17 @@ func newNodeWithCreationTime(name, bootID string, annotations map[string]string,
 	}
 }
 
-// newNotReadyNode is like newNode but the Ready condition is False.
+// newNotReadyNode is like newNode but the Ready condition is False. The
+// Ready condition's LastTransitionTime is set to the node's creationTime so
+// callers can control how long the node has been not Ready.
 func newNotReadyNode(name, bootID string, annotations map[string]string, creationTime time.Time) *corev1.Node {
 	n := newNodeWithCreationTime(name, bootID, annotations, creationTime)
 	n.Status.Conditions = []corev1.NodeCondition{
-		{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+		{
+			Type:               corev1.NodeReady,
+			Status:             corev1.ConditionFalse,
+			LastTransitionTime: metav1.NewTime(creationTime),
+		},
 	}
 	return n
 }
@@ -149,10 +155,19 @@ func TestNodeRebootReconcile(t *testing.T) {
 			name: "reboot detected but node not Ready yet — no CNH, annotation unchanged, requeues",
 			node: newNotReadyNode("node-1", "boot-bbb", map[string]string{
 				AnnotationLastBootID: "boot-aaa",
-			}, time.Time{}),
+			}, time.Now()),
 			expectCNH:      false,
 			expectBootAnno: "boot-aaa",
 			expectRequeue:  NodeReadyRequeueInterval,
+		},
+		{
+			name: "reboot detected, node not Ready past max wait — no CNH, annotation unchanged, no requeue",
+			node: newNotReadyNode("node-1", "boot-bbb", map[string]string{
+				AnnotationLastBootID: "boot-aaa",
+			}, time.Now().Add(-(NodeReadyMaxWait + time.Minute))),
+			expectCNH:      false,
+			expectBootAnno: "boot-aaa",
+			expectRequeue:  0,
 		},
 	}
 

--- a/test/e2e/nodereboot_test.go
+++ b/test/e2e/nodereboot_test.go
@@ -81,7 +81,7 @@ var _ = Describe("NodeReboot Controller", Ordered, ContinueOnFailure, Label("nod
 				}
 			}
 			return true
-		}, "2m", "2s").Should(BeTrue(), "Not all nodes have the last-boot-id annotation")
+		}, "60s", "2s").Should(BeTrue(), "Not all nodes have the last-boot-id annotation")
 
 		By("Verifying annotation matches the node's actual bootID")
 		for _, node := range nodeList.Items {

--- a/test/e2e/nodereboot_test.go
+++ b/test/e2e/nodereboot_test.go
@@ -39,6 +39,33 @@ var _ = Describe("NodeReboot Controller", Ordered, ContinueOnFailure, Label("nod
 		Expect(err).NotTo(HaveOccurred())
 		Expect(nodeList.Items).NotTo(BeEmpty(), "No nodes found in cluster")
 
+		By("Waiting for all nodes to report Ready=True")
+		// The controller intentionally defers initializing the bootID
+		// annotation on a brand-new node until that node reports Ready, so
+		// that a CheckNodeHealth CR can also be created. In Kind, the
+		// control-plane node can take a couple of minutes to become Ready
+		// after cluster startup.
+		Eventually(func() bool {
+			nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+			if err != nil {
+				return false
+			}
+			for _, node := range nodes.Items {
+				ready := false
+				for _, c := range node.Status.Conditions {
+					if c.Type == "Ready" && c.Status == "True" {
+						ready = true
+						break
+					}
+				}
+				if !ready {
+					GinkgoWriter.Printf("Node %s is not Ready yet\n", node.Name)
+					return false
+				}
+			}
+			return true
+		}, "5m", "5s").Should(BeTrue(), "Not all nodes became Ready in time")
+
 		By("Verifying each node has the last-boot-id annotation set")
 		Eventually(func() bool {
 			nodeList, err = clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
@@ -54,7 +81,7 @@ var _ = Describe("NodeReboot Controller", Ordered, ContinueOnFailure, Label("nod
 				}
 			}
 			return true
-		}, "60s", "2s").Should(BeTrue(), "Not all nodes have the last-boot-id annotation")
+		}, "2m", "2s").Should(BeTrue(), "Not all nodes have the last-boot-id annotation")
 
 		By("Verifying annotation matches the node's actual bootID")
 		for _, node := range nodeList.Items {


### PR DESCRIPTION
Health checking nodes before they are ready will generate meaningless results.