### PR TITLE
Do not create health check CR until karpenter.sh/initialized=true

### DIFF
--- a/pkg/controller/node/controller.go
+++ b/pkg/controller/node/controller.go
@@ -58,7 +58,7 @@ const (
 	// timeout (10m); the in-house Remediator uses 5m for the same condition.
 	NodeReadyMaxWait = 10 * time.Minute
 
-	// KarpenterCapacityTyeLabel is set by Karpenter on every node it manages and
+	// KarpenterCapacityTypeLabel is set by Karpenter on every node it manages and
 	// holds the name of the capacity type (e.g., "spot" or "on-demand") for the
 	// node. It is used to determine whether a node is Karpenter-managed.
 	KarpenterCapacityTypeLabel = "karpenter.sh/capacity-type"

--- a/pkg/controller/node/controller.go
+++ b/pkg/controller/node/controller.go
@@ -57,6 +57,13 @@ const (
 	// forever. The value is aligned with Karpenter's Node Auto Repair unready
 	// timeout (10m); the in-house Remediator uses 5m for the same condition.
 	NodeReadyMaxWait = 10 * time.Minute
+
+	// KarpenterUnregisteredTaintKey is the taint key Karpenter applies to
+	// nodes it has provisioned but not yet finished registering. The taint is
+	// removed by Karpenter once the node has been registered, so we defer
+	// CheckNodeHealth creation until then to avoid running checks against a
+	// node that is not yet fully initialized.
+	KarpenterUnregisteredTaintKey = "karpenter.sh/unregistered"
 )
 
 // NodeRebootReconciler watches Node objects and creates CheckNodeHealth CRs
@@ -168,6 +175,11 @@ func (r *NodeRebootReconciler) createCheckNodeHealth(ctx context.Context, node *
 		klog.InfoS("Node is not Ready yet, deferring CheckNodeHealth creation", "node", node.Name, "bootID", bootID)
 		return false, nil
 	}
+	if hasKarpenterUnregisteredTaint(node) {
+		klog.InfoS("Karpenter node not registered yet, deferring CheckNodeHealth creation",
+			"node", node.Name, "bootID", bootID, "taint", KarpenterUnregisteredTaintKey)
+		return false, nil
+	}
 
 	crName := GenerateCNHName(node.Name, bootID)
 	cnh := &chmv1alpha1.CheckNodeHealth{
@@ -202,12 +214,30 @@ func isNodeReady(node *corev1.Node) bool {
 	return false
 }
 
+// hasKarpenterUnregisteredTaint reports whether the node carries Karpenter's
+// unregistered taint, indicating that Karpenter has not yet finished
+// registering the node.
+func hasKarpenterUnregisteredTaint(node *corev1.Node) bool {
+	for _, t := range node.Spec.Taints {
+		if t.Key == KarpenterUnregisteredTaintKey {
+			return true
+		}
+	}
+	return false
+}
+
 // notReadyExceeds reports whether the node's Ready condition is not True and
 // its LastTransitionTime is older than the given duration. If the Ready
 // condition is missing, the node's CreationTimestamp is used as the reference
 // point so freshly observed nodes without a Ready condition are not
 // immediately considered to have exceeded the wait.
 func notReadyExceeds(node *corev1.Node, d time.Duration) bool {
+	// If a Karpenter node is Ready=True but still has the unregistered taint,
+	// bound the wait using the node's CreationTimestamp so we don't requeue
+	// forever should Karpenter never remove the taint.
+	if hasKarpenterUnregisteredTaint(node) && isNodeReady(node) {
+		return time.Since(node.CreationTimestamp.Time) > d
+	}
 	for _, c := range node.Status.Conditions {
 		if c.Type != corev1.NodeReady {
 			continue

--- a/pkg/controller/node/controller.go
+++ b/pkg/controller/node/controller.go
@@ -259,7 +259,7 @@ func notReadyExceeds(node *corev1.Node, d time.Duration) bool {
 	// If a Karpenter node is Ready=True but not yet initialized, bound the
 	// wait using the node's CreationTimestamp so we don't requeue forever
 	// should Karpenter never set the initialized label.
-	if isKarpenterManaged(node) && !isKarpenterInitialized(node) && isNodeReady(node) {
+	if isKarpenterManaged(node) && !isKarpenterInitialized(node) {
 		return time.Since(node.CreationTimestamp.Time) > d
 	}
 	for _, c := range node.Status.Conditions {

--- a/pkg/controller/node/controller.go
+++ b/pkg/controller/node/controller.go
@@ -167,6 +167,8 @@ func (r *NodeRebootReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 // createCheckNodeHealth creates a CheckNodeHealth CR with a deterministic
 // name, but only if the node currently reports Ready=True. Running the health
+// createCheckNodeHealth creates a CheckNodeHealth CR with a deterministic
+// name, but only if the node has been initialized. Running the health
 // checks against a node that has not finished initializing (e.g., still
 // booting after a reboot) would produce spurious failures, so the caller
 // should requeue and retry when this returns (false, nil).

--- a/pkg/controller/node/controller.go
+++ b/pkg/controller/node/controller.go
@@ -58,10 +58,10 @@ const (
 	// timeout (10m); the in-house Remediator uses 5m for the same condition.
 	NodeReadyMaxWait = 10 * time.Minute
 
-	// KarpenterNodePoolLabel is set by Karpenter on every node it manages and
-	// holds the name of the owning NodePool. Its presence is used to detect
-	// whether a node is Karpenter-managed.
-	KarpenterNodePoolLabel = "karpenter.sh/capacity-type"
+	// KarpenterCapacityTyeLabel is set by Karpenter on every node it manages and
+	// holds the name of the capacity type (e.g., "spot" or "on-demand") for the
+	// node. It is used to determine whether a node is Karpenter-managed.
+	KarpenterCapacityTypeLabel = "karpenter.sh/capacity-type"
 
 	// KarpenterInitializedLabel is set to "true" by Karpenter once a node it
 	// manages has finished initializing (Ready, startup taints removed, etc.).
@@ -222,7 +222,7 @@ func isNodeReady(node *corev1.Node) bool {
 // isKarpenterManaged reports whether the node is managed by Karpenter,
 // detected via the presence of the karpenter.sh/nodepool label.
 func isKarpenterManaged(node *corev1.Node) bool {
-	v, ok := node.Labels[KarpenterNodePoolLabel]
+	v, ok := node.Labels[KarpenterCapacityTypeLabel]
 	return ok && v != ""
 }
 

--- a/pkg/controller/node/controller.go
+++ b/pkg/controller/node/controller.go
@@ -58,12 +58,17 @@ const (
 	// timeout (10m); the in-house Remediator uses 5m for the same condition.
 	NodeReadyMaxWait = 10 * time.Minute
 
-	// KarpenterUnregisteredTaintKey is the taint key Karpenter applies to
-	// nodes it has provisioned but not yet finished registering. The taint is
-	// removed by Karpenter once the node has been registered, so we defer
-	// CheckNodeHealth creation until then to avoid running checks against a
-	// node that is not yet fully initialized.
-	KarpenterUnregisteredTaintKey = "karpenter.sh/unregistered"
+	// KarpenterNodePoolLabel is set by Karpenter on every node it manages and
+	// holds the name of the owning NodePool. Its presence is used to detect
+	// whether a node is Karpenter-managed.
+	KarpenterNodePoolLabel = "karpenter.sh/nodepool"
+
+	// KarpenterInitializedLabel is set to "true" by Karpenter once a node it
+	// manages has finished initializing (Ready, startup taints removed, etc.).
+	// CheckNodeHealth creation is deferred for Karpenter-managed nodes until
+	// this label is true to avoid running checks against a node that is not
+	// yet fully initialized.
+	KarpenterInitializedLabel = "karpenter.sh/initialized"
 )
 
 // NodeRebootReconciler watches Node objects and creates CheckNodeHealth CRs
@@ -175,9 +180,9 @@ func (r *NodeRebootReconciler) createCheckNodeHealth(ctx context.Context, node *
 		klog.InfoS("Node is not Ready yet, deferring CheckNodeHealth creation", "node", node.Name, "bootID", bootID)
 		return false, nil
 	}
-	if hasKarpenterUnregisteredTaint(node) {
-		klog.InfoS("Karpenter node not registered yet, deferring CheckNodeHealth creation",
-			"node", node.Name, "bootID", bootID, "taint", KarpenterUnregisteredTaintKey)
+	if isKarpenterManaged(node) && !isKarpenterInitialized(node) {
+		klog.InfoS("Karpenter node not initialized yet, deferring CheckNodeHealth creation",
+			"node", node.Name, "bootID", bootID, "label", KarpenterInitializedLabel)
 		return false, nil
 	}
 
@@ -214,16 +219,17 @@ func isNodeReady(node *corev1.Node) bool {
 	return false
 }
 
-// hasKarpenterUnregisteredTaint reports whether the node carries Karpenter's
-// unregistered taint, indicating that Karpenter has not yet finished
-// registering the node.
-func hasKarpenterUnregisteredTaint(node *corev1.Node) bool {
-	for _, t := range node.Spec.Taints {
-		if t.Key == KarpenterUnregisteredTaintKey {
-			return true
-		}
-	}
-	return false
+// isKarpenterManaged reports whether the node is managed by Karpenter,
+// detected via the presence of the karpenter.sh/nodepool label.
+func isKarpenterManaged(node *corev1.Node) bool {
+	v, ok := node.Labels[KarpenterNodePoolLabel]
+	return ok && v != ""
+}
+
+// isKarpenterInitialized reports whether Karpenter has marked the node as
+// initialized via the karpenter.sh/initialized=true label.
+func isKarpenterInitialized(node *corev1.Node) bool {
+	return node.Labels[KarpenterInitializedLabel] == "true"
 }
 
 // notReadyExceeds reports whether the node's Ready condition is not True and
@@ -232,10 +238,10 @@ func hasKarpenterUnregisteredTaint(node *corev1.Node) bool {
 // point so freshly observed nodes without a Ready condition are not
 // immediately considered to have exceeded the wait.
 func notReadyExceeds(node *corev1.Node, d time.Duration) bool {
-	// If a Karpenter node is Ready=True but still has the unregistered taint,
-	// bound the wait using the node's CreationTimestamp so we don't requeue
-	// forever should Karpenter never remove the taint.
-	if hasKarpenterUnregisteredTaint(node) && isNodeReady(node) {
+	// If a Karpenter node is Ready=True but not yet initialized, bound the
+	// wait using the node's CreationTimestamp so we don't requeue forever
+	// should Karpenter never set the initialized label.
+	if isKarpenterManaged(node) && !isKarpenterInitialized(node) && isNodeReady(node) {
 		return time.Since(node.CreationTimestamp.Time) > d
 	}
 	for _, c := range node.Status.Conditions {

--- a/pkg/controller/node/controller.go
+++ b/pkg/controller/node/controller.go
@@ -166,8 +166,6 @@ func (r *NodeRebootReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 }
 
 // createCheckNodeHealth creates a CheckNodeHealth CR with a deterministic
-// name, but only if the node currently reports Ready=True. Running the health
-// createCheckNodeHealth creates a CheckNodeHealth CR with a deterministic
 // name, but only if the node has been initialized. Running the health
 // checks against a node that has not finished initializing (e.g., still
 // booting after a reboot) would produce spurious failures, so the caller

--- a/pkg/controller/node/controller.go
+++ b/pkg/controller/node/controller.go
@@ -176,13 +176,7 @@ func (r *NodeRebootReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 // with the same name already exists (e.g., from a duplicate reconcile), the
 // AlreadyExists error is safely ignored.
 func (r *NodeRebootReconciler) createCheckNodeHealth(ctx context.Context, node *corev1.Node, bootID string) (bool, error) {
-	if !isNodeReady(node) {
-		klog.InfoS("Node is not Ready yet, deferring CheckNodeHealth creation", "node", node.Name, "bootID", bootID)
-		return false, nil
-	}
-	if isKarpenterManaged(node) && !isKarpenterInitialized(node) {
-		klog.InfoS("Karpenter node not initialized yet, deferring CheckNodeHealth creation",
-			"node", node.Name, "bootID", bootID, "label", KarpenterInitializedLabel)
+	if !isNodeReadyForHealthCheck(node, bootID) {
 		return false, nil
 	}
 
@@ -207,6 +201,30 @@ func (r *NodeRebootReconciler) createCheckNodeHealth(ctx context.Context, node *
 	}
 	klog.InfoS("Created CheckNodeHealth for rebooted node", "name", crName, "node", node.Name, "bootID", bootID)
 	return true, nil
+}
+
+// isNodeReadyForHealthCheck reports whether the node is ready to have a
+// CheckNodeHealth CR created against it. A node is considered ready when its
+// Ready condition is True and, if managed by Karpenter, the
+// karpenter.sh/initialized label is set to "true". When the node is not yet
+// ready, a log line is emitted explaining why so the caller can simply
+// requeue without additional logging.
+func isNodeReadyForHealthCheck(node *corev1.Node, bootID string) bool {
+	if isKarpenterManaged(node) {
+		if !isKarpenterInitialized(node) {
+			klog.InfoS("Karpenter node not initialized yet, deferring CheckNodeHealth creation",
+				"node", node.Name, "bootID", bootID, "label", KarpenterInitializedLabel)
+			return false
+		}
+		return true
+	}
+
+	// Non-Karpenter nodes are considered ready when the Ready condition is True.
+	if !isNodeReady(node) {
+		klog.InfoS("Node is not Ready yet, deferring CheckNodeHealth creation", "node", node.Name, "bootID", bootID)
+		return false
+	}
+	return true
 }
 
 // isNodeReady reports whether the node has a Ready condition with status True.

--- a/pkg/controller/node/controller.go
+++ b/pkg/controller/node/controller.go
@@ -61,7 +61,7 @@ const (
 	// KarpenterNodePoolLabel is set by Karpenter on every node it manages and
 	// holds the name of the owning NodePool. Its presence is used to detect
 	// whether a node is Karpenter-managed.
-	KarpenterNodePoolLabel = "karpenter.sh/nodepool"
+	KarpenterNodePoolLabel = "karpenter.sh/capacity-type"
 
 	// KarpenterInitializedLabel is set to "true" by Karpenter once a node it
 	// manages has finished initializing (Ready, startup taints removed, etc.).

--- a/pkg/controller/node/controller_test.go
+++ b/pkg/controller/node/controller_test.go
@@ -79,6 +79,17 @@ func newNotReadyNode(name, bootID string, annotations map[string]string, creatio
 	return n
 }
 
+// newKarpenterUnregisteredNode returns a Ready=True node carrying Karpenter's
+// unregistered taint, simulating a node that has been provisioned but not yet
+// registered by Karpenter.
+func newKarpenterUnregisteredNode(name, bootID string, annotations map[string]string, creationTime time.Time) *corev1.Node {
+	n := newNodeWithCreationTime(name, bootID, annotations, creationTime)
+	n.Spec.Taints = []corev1.Taint{
+		{Key: KarpenterUnregisteredTaintKey, Effect: corev1.TaintEffectNoSchedule},
+	}
+	return n
+}
+
 func TestNodeRebootReconcile(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -163,6 +174,31 @@ func TestNodeRebootReconcile(t *testing.T) {
 		{
 			name: "reboot detected, node not Ready past max wait — no CNH, annotation unchanged, no requeue",
 			node: newNotReadyNode("node-1", "boot-bbb", map[string]string{
+				AnnotationLastBootID: "boot-aaa",
+			}, time.Now().Add(-(NodeReadyMaxWait + time.Minute))),
+			expectCNH:      false,
+			expectBootAnno: "boot-aaa",
+			expectRequeue:  0,
+		},
+		{
+			name:           "new Karpenter node still unregistered — no CNH, annotation not set, requeues",
+			node:           newKarpenterUnregisteredNode("node-1", "boot-aaa", nil, time.Now()),
+			expectCNH:      false,
+			expectBootAnno: "",
+			expectRequeue:  NodeReadyRequeueInterval,
+		},
+		{
+			name: "reboot detected on Karpenter node still unregistered — no CNH, annotation unchanged, requeues",
+			node: newKarpenterUnregisteredNode("node-1", "boot-bbb", map[string]string{
+				AnnotationLastBootID: "boot-aaa",
+			}, time.Now()),
+			expectCNH:      false,
+			expectBootAnno: "boot-aaa",
+			expectRequeue:  NodeReadyRequeueInterval,
+		},
+		{
+			name: "reboot detected on Karpenter node still unregistered past max wait — no CNH, annotation unchanged, no requeue",
+			node: newKarpenterUnregisteredNode("node-1", "boot-bbb", map[string]string{
 				AnnotationLastBootID: "boot-aaa",
 			}, time.Now().Add(-(NodeReadyMaxWait + time.Minute))),
 			expectCNH:      false,
@@ -419,6 +455,76 @@ func TestCreateCheckNodeHealthSkipsWhenNotReady(t *testing.T) {
 		cnh := &chmv1alpha1.CheckNodeHealth{}
 		if err := fc.Get(context.Background(), client.ObjectKey{Name: GenerateCNHName("node-1", "boot-aaa")}, cnh); err != nil {
 			t.Errorf("expected CheckNodeHealth to be created: %v", err)
+		}
+	})
+
+	t.Run("Karpenter unregistered taint returns (false, nil) and creates no CR", func(t *testing.T) {
+		node := newKarpenterUnregisteredNode("node-1", "boot-aaa", nil, time.Now())
+		r, fc := setupRebootTest(node)
+
+		created, err := r.createCheckNodeHealth(context.Background(), node, "boot-aaa")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if created {
+			t.Fatal("expected created=false when Karpenter unregistered taint is present")
+		}
+
+		cnh := &chmv1alpha1.CheckNodeHealth{}
+		gotErr := fc.Get(context.Background(), client.ObjectKey{Name: GenerateCNHName("node-1", "boot-aaa")}, cnh)
+		if !apierrors.IsNotFound(gotErr) {
+			t.Errorf("expected NotFound error for CheckNodeHealth, got %v", gotErr)
+		}
+	})
+}
+
+func TestHasKarpenterUnregisteredTaint(t *testing.T) {
+	tests := []struct {
+		name   string
+		taints []corev1.Taint
+		want   bool
+	}{
+		{name: "no taints", taints: nil, want: false},
+		{
+			name:   "unrelated taint",
+			taints: []corev1.Taint{{Key: "node.kubernetes.io/unreachable", Effect: corev1.TaintEffectNoSchedule}},
+			want:   false,
+		},
+		{
+			name:   "karpenter unregistered taint present",
+			taints: []corev1.Taint{{Key: KarpenterUnregisteredTaintKey, Effect: corev1.TaintEffectNoSchedule}},
+			want:   true,
+		},
+		{
+			name: "karpenter unregistered taint among others",
+			taints: []corev1.Taint{
+				{Key: "node.kubernetes.io/unreachable", Effect: corev1.TaintEffectNoSchedule},
+				{Key: KarpenterUnregisteredTaintKey, Effect: corev1.TaintEffectNoSchedule},
+			},
+			want: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			node := &corev1.Node{Spec: corev1.NodeSpec{Taints: tc.taints}}
+			if got := hasKarpenterUnregisteredTaint(node); got != tc.want {
+				t.Errorf("hasKarpenterUnregisteredTaint = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNotReadyExceedsKarpenterTainted(t *testing.T) {
+	t.Run("Ready=True with taint, recent — does not exceed", func(t *testing.T) {
+		node := newKarpenterUnregisteredNode("node-1", "boot-aaa", nil, time.Now())
+		if notReadyExceeds(node, NodeReadyMaxWait) {
+			t.Error("expected notReadyExceeds=false for recently created tainted node")
+		}
+	})
+	t.Run("Ready=True with taint, old — exceeds", func(t *testing.T) {
+		node := newKarpenterUnregisteredNode("node-1", "boot-aaa", nil, time.Now().Add(-(NodeReadyMaxWait + time.Minute)))
+		if !notReadyExceeds(node, NodeReadyMaxWait) {
+			t.Error("expected notReadyExceeds=true for old tainted node")
 		}
 	})
 }

--- a/pkg/controller/node/controller_test.go
+++ b/pkg/controller/node/controller_test.go
@@ -79,13 +79,18 @@ func newNotReadyNode(name, bootID string, annotations map[string]string, creatio
 	return n
 }
 
-// newKarpenterUnregisteredNode returns a Ready=True node carrying Karpenter's
-// unregistered taint, simulating a node that has been provisioned but not yet
-// registered by Karpenter.
-func newKarpenterUnregisteredNode(name, bootID string, annotations map[string]string, creationTime time.Time) *corev1.Node {
+// newKarpenterNode returns a Ready=True node managed by Karpenter. If
+// initialized is true, the karpenter.sh/initialized=true label is set;
+// otherwise the label is absent (simulating a node that Karpenter has not
+// yet finished initializing).
+func newKarpenterNode(name, bootID string, annotations map[string]string, creationTime time.Time, initialized bool) *corev1.Node {
 	n := newNodeWithCreationTime(name, bootID, annotations, creationTime)
-	n.Spec.Taints = []corev1.Taint{
-		{Key: KarpenterUnregisteredTaintKey, Effect: corev1.TaintEffectNoSchedule},
+	if n.Labels == nil {
+		n.Labels = map[string]string{}
+	}
+	n.Labels[KarpenterNodePoolLabel] = "default"
+	if initialized {
+		n.Labels[KarpenterInitializedLabel] = "true"
 	}
 	return n
 }
@@ -181,29 +186,36 @@ func TestNodeRebootReconcile(t *testing.T) {
 			expectRequeue:  0,
 		},
 		{
-			name:           "new Karpenter node still unregistered — no CNH, annotation not set, requeues",
-			node:           newKarpenterUnregisteredNode("node-1", "boot-aaa", nil, time.Now()),
+			name:           "new Karpenter node not initialized — no CNH, annotation not set, requeues",
+			node:           newKarpenterNode("node-1", "boot-aaa", nil, time.Now(), false),
 			expectCNH:      false,
 			expectBootAnno: "",
 			expectRequeue:  NodeReadyRequeueInterval,
 		},
 		{
-			name: "reboot detected on Karpenter node still unregistered — no CNH, annotation unchanged, requeues",
-			node: newKarpenterUnregisteredNode("node-1", "boot-bbb", map[string]string{
+			name: "reboot detected on Karpenter node not initialized — no CNH, annotation unchanged, requeues",
+			node: newKarpenterNode("node-1", "boot-bbb", map[string]string{
 				AnnotationLastBootID: "boot-aaa",
-			}, time.Now()),
+			}, time.Now(), false),
 			expectCNH:      false,
 			expectBootAnno: "boot-aaa",
 			expectRequeue:  NodeReadyRequeueInterval,
 		},
 		{
-			name: "reboot detected on Karpenter node still unregistered past max wait — no CNH, annotation unchanged, no requeue",
-			node: newKarpenterUnregisteredNode("node-1", "boot-bbb", map[string]string{
+			name: "reboot detected on Karpenter node not initialized past max wait — no CNH, annotation unchanged, no requeue",
+			node: newKarpenterNode("node-1", "boot-bbb", map[string]string{
 				AnnotationLastBootID: "boot-aaa",
-			}, time.Now().Add(-(NodeReadyMaxWait + time.Minute))),
+			}, time.Now().Add(-(NodeReadyMaxWait + time.Minute)), false),
 			expectCNH:      false,
 			expectBootAnno: "boot-aaa",
 			expectRequeue:  0,
+		},
+		{
+			name:           "new Karpenter node already initialized — creates CNH",
+			node:           newKarpenterNode("node-1", "boot-aaa", nil, time.Now(), true),
+			expectCNH:      true,
+			expectBootAnno: "boot-aaa",
+			expectRequeue:  NodeConditionTTL,
 		},
 	}
 
@@ -458,8 +470,8 @@ func TestCreateCheckNodeHealthSkipsWhenNotReady(t *testing.T) {
 		}
 	})
 
-	t.Run("Karpenter unregistered taint returns (false, nil) and creates no CR", func(t *testing.T) {
-		node := newKarpenterUnregisteredNode("node-1", "boot-aaa", nil, time.Now())
+	t.Run("Karpenter node not initialized returns (false, nil) and creates no CR", func(t *testing.T) {
+		node := newKarpenterNode("node-1", "boot-aaa", nil, time.Now(), false)
 		r, fc := setupRebootTest(node)
 
 		created, err := r.createCheckNodeHealth(context.Background(), node, "boot-aaa")
@@ -467,7 +479,7 @@ func TestCreateCheckNodeHealthSkipsWhenNotReady(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if created {
-			t.Fatal("expected created=false when Karpenter unregistered taint is present")
+			t.Fatal("expected created=false when Karpenter node is not initialized")
 		}
 
 		cnh := &chmv1alpha1.CheckNodeHealth{}
@@ -476,55 +488,95 @@ func TestCreateCheckNodeHealthSkipsWhenNotReady(t *testing.T) {
 			t.Errorf("expected NotFound error for CheckNodeHealth, got %v", gotErr)
 		}
 	})
+
+	t.Run("Karpenter node initialized returns (true, nil) and creates CR", func(t *testing.T) {
+		node := newKarpenterNode("node-1", "boot-aaa", nil, time.Now(), true)
+		r, fc := setupRebootTest(node)
+
+		created, err := r.createCheckNodeHealth(context.Background(), node, "boot-aaa")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !created {
+			t.Fatal("expected created=true when Karpenter node is initialized")
+		}
+
+		cnh := &chmv1alpha1.CheckNodeHealth{}
+		if err := fc.Get(context.Background(), client.ObjectKey{Name: GenerateCNHName("node-1", "boot-aaa")}, cnh); err != nil {
+			t.Errorf("expected CheckNodeHealth to be created: %v", err)
+		}
+	})
 }
 
-func TestHasKarpenterUnregisteredTaint(t *testing.T) {
+func TestKarpenterHelpers(t *testing.T) {
 	tests := []struct {
-		name   string
-		taints []corev1.Taint
-		want   bool
+		name            string
+		labels          map[string]string
+		wantManaged     bool
+		wantInitialized bool
 	}{
-		{name: "no taints", taints: nil, want: false},
+		{name: "no labels", labels: nil, wantManaged: false, wantInitialized: false},
 		{
-			name:   "unrelated taint",
-			taints: []corev1.Taint{{Key: "node.kubernetes.io/unreachable", Effect: corev1.TaintEffectNoSchedule}},
-			want:   false,
+			name:            "managed but not initialized",
+			labels:          map[string]string{KarpenterNodePoolLabel: "default"},
+			wantManaged:     true,
+			wantInitialized: false,
 		},
 		{
-			name:   "karpenter unregistered taint present",
-			taints: []corev1.Taint{{Key: KarpenterUnregisteredTaintKey, Effect: corev1.TaintEffectNoSchedule}},
-			want:   true,
+			name:            "managed and initialized",
+			labels:          map[string]string{KarpenterNodePoolLabel: "default", KarpenterInitializedLabel: "true"},
+			wantManaged:     true,
+			wantInitialized: true,
 		},
 		{
-			name: "karpenter unregistered taint among others",
-			taints: []corev1.Taint{
-				{Key: "node.kubernetes.io/unreachable", Effect: corev1.TaintEffectNoSchedule},
-				{Key: KarpenterUnregisteredTaintKey, Effect: corev1.TaintEffectNoSchedule},
-			},
-			want: true,
+			name:            "initialized label not 'true'",
+			labels:          map[string]string{KarpenterNodePoolLabel: "default", KarpenterInitializedLabel: "false"},
+			wantManaged:     true,
+			wantInitialized: false,
+		},
+		{
+			name:            "initialized label without nodepool",
+			labels:          map[string]string{KarpenterInitializedLabel: "true"},
+			wantManaged:     false,
+			wantInitialized: true,
+		},
+		{
+			name:            "nodepool label present but empty value",
+			labels:          map[string]string{KarpenterNodePoolLabel: ""},
+			wantManaged:     false,
+			wantInitialized: false,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			node := &corev1.Node{Spec: corev1.NodeSpec{Taints: tc.taints}}
-			if got := hasKarpenterUnregisteredTaint(node); got != tc.want {
-				t.Errorf("hasKarpenterUnregisteredTaint = %v, want %v", got, tc.want)
+			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Labels: tc.labels}}
+			if got := isKarpenterManaged(node); got != tc.wantManaged {
+				t.Errorf("isKarpenterManaged = %v, want %v", got, tc.wantManaged)
+			}
+			if got := isKarpenterInitialized(node); got != tc.wantInitialized {
+				t.Errorf("isKarpenterInitialized = %v, want %v", got, tc.wantInitialized)
 			}
 		})
 	}
 }
 
-func TestNotReadyExceedsKarpenterTainted(t *testing.T) {
-	t.Run("Ready=True with taint, recent — does not exceed", func(t *testing.T) {
-		node := newKarpenterUnregisteredNode("node-1", "boot-aaa", nil, time.Now())
+func TestNotReadyExceedsKarpenterUninitialized(t *testing.T) {
+	t.Run("Karpenter Ready=True not initialized, recent — does not exceed", func(t *testing.T) {
+		node := newKarpenterNode("node-1", "boot-aaa", nil, time.Now(), false)
 		if notReadyExceeds(node, NodeReadyMaxWait) {
-			t.Error("expected notReadyExceeds=false for recently created tainted node")
+			t.Error("expected notReadyExceeds=false for recently created uninitialized node")
 		}
 	})
-	t.Run("Ready=True with taint, old — exceeds", func(t *testing.T) {
-		node := newKarpenterUnregisteredNode("node-1", "boot-aaa", nil, time.Now().Add(-(NodeReadyMaxWait + time.Minute)))
+	t.Run("Karpenter Ready=True not initialized, old — exceeds", func(t *testing.T) {
+		node := newKarpenterNode("node-1", "boot-aaa", nil, time.Now().Add(-(NodeReadyMaxWait + time.Minute)), false)
 		if !notReadyExceeds(node, NodeReadyMaxWait) {
-			t.Error("expected notReadyExceeds=true for old tainted node")
+			t.Error("expected notReadyExceeds=true for old uninitialized node")
+		}
+	})
+	t.Run("Karpenter Ready=True initialized — does not exceed", func(t *testing.T) {
+		node := newKarpenterNode("node-1", "boot-aaa", nil, time.Now().Add(-(NodeReadyMaxWait + time.Minute)), true)
+		if notReadyExceeds(node, NodeReadyMaxWait) {
+			t.Error("expected notReadyExceeds=false for initialized Ready=True node")
 		}
 	})
 }

--- a/pkg/controller/node/controller_test.go
+++ b/pkg/controller/node/controller_test.go
@@ -88,7 +88,7 @@ func newKarpenterNode(name, bootID string, annotations map[string]string, creati
 	if n.Labels == nil {
 		n.Labels = map[string]string{}
 	}
-	n.Labels[KarpenterNodePoolLabel] = "spot"
+	n.Labels[KarpenterCapacityTypeLabel] = "spot"
 	if initialized {
 		n.Labels[KarpenterInitializedLabel] = "true"
 	}
@@ -518,19 +518,19 @@ func TestKarpenterHelpers(t *testing.T) {
 		{name: "no labels", labels: nil, wantManaged: false, wantInitialized: false},
 		{
 			name:            "managed (spot) but not initialized",
-			labels:          map[string]string{KarpenterNodePoolLabel: "spot"},
+			labels:          map[string]string{KarpenterCapacityTypeLabel: "spot"},
 			wantManaged:     true,
 			wantInitialized: false,
 		},
 		{
 			name:            "managed (on-demand) and initialized",
-			labels:          map[string]string{KarpenterNodePoolLabel: "on-demand", KarpenterInitializedLabel: "true"},
+			labels:          map[string]string{KarpenterCapacityTypeLabel: "on-demand", KarpenterInitializedLabel: "true"},
 			wantManaged:     true,
 			wantInitialized: true,
 		},
 		{
 			name:            "initialized label not 'true'",
-			labels:          map[string]string{KarpenterNodePoolLabel: "spot", KarpenterInitializedLabel: "false"},
+			labels:          map[string]string{KarpenterCapacityTypeLabel: "spot", KarpenterInitializedLabel: "false"},
 			wantManaged:     true,
 			wantInitialized: false,
 		},
@@ -542,7 +542,7 @@ func TestKarpenterHelpers(t *testing.T) {
 		},
 		{
 			name:            "capacity-type label present but empty value",
-			labels:          map[string]string{KarpenterNodePoolLabel: ""},
+			labels:          map[string]string{KarpenterCapacityTypeLabel: ""},
 			wantManaged:     false,
 			wantInitialized: false,
 		},

--- a/pkg/controller/node/controller_test.go
+++ b/pkg/controller/node/controller_test.go
@@ -88,7 +88,7 @@ func newKarpenterNode(name, bootID string, annotations map[string]string, creati
 	if n.Labels == nil {
 		n.Labels = map[string]string{}
 	}
-	n.Labels[KarpenterNodePoolLabel] = "default"
+	n.Labels[KarpenterNodePoolLabel] = "spot"
 	if initialized {
 		n.Labels[KarpenterInitializedLabel] = "true"
 	}
@@ -517,31 +517,31 @@ func TestKarpenterHelpers(t *testing.T) {
 	}{
 		{name: "no labels", labels: nil, wantManaged: false, wantInitialized: false},
 		{
-			name:            "managed but not initialized",
-			labels:          map[string]string{KarpenterNodePoolLabel: "default"},
+			name:            "managed (spot) but not initialized",
+			labels:          map[string]string{KarpenterNodePoolLabel: "spot"},
 			wantManaged:     true,
 			wantInitialized: false,
 		},
 		{
-			name:            "managed and initialized",
-			labels:          map[string]string{KarpenterNodePoolLabel: "default", KarpenterInitializedLabel: "true"},
+			name:            "managed (on-demand) and initialized",
+			labels:          map[string]string{KarpenterNodePoolLabel: "on-demand", KarpenterInitializedLabel: "true"},
 			wantManaged:     true,
 			wantInitialized: true,
 		},
 		{
 			name:            "initialized label not 'true'",
-			labels:          map[string]string{KarpenterNodePoolLabel: "default", KarpenterInitializedLabel: "false"},
+			labels:          map[string]string{KarpenterNodePoolLabel: "spot", KarpenterInitializedLabel: "false"},
 			wantManaged:     true,
 			wantInitialized: false,
 		},
 		{
-			name:            "initialized label without nodepool",
+			name:            "initialized label without capacity-type",
 			labels:          map[string]string{KarpenterInitializedLabel: "true"},
 			wantManaged:     false,
 			wantInitialized: true,
 		},
 		{
-			name:            "nodepool label present but empty value",
+			name:            "capacity-type label present but empty value",
 			labels:          map[string]string{KarpenterNodePoolLabel: ""},
 			wantManaged:     false,
 			wantInitialized: false,

--- a/pkg/controller/node/controller_test.go
+++ b/pkg/controller/node/controller_test.go
@@ -439,17 +439,17 @@ func TestIsNodeReadyForHealthCheck(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "non-Karpenter Ready=True — ready",
+			name: "non-Karpenter node condition Ready=True — ready for health check",
 			node: newNodeWithCreationTime("node-1", "boot-aaa", nil, time.Now()),
 			want: true,
 		},
 		{
-			name: "non-Karpenter Ready=False — not ready",
+			name: "non-Karpenter node condition Ready=False — not ready for health check",
 			node: newNotReadyNode("node-1", "boot-aaa", nil, time.Now()),
 			want: false,
 		},
 		{
-			name: "non-Karpenter no Ready condition — not ready",
+			name: "non-Karpenter no Ready condition — not ready for health check",
 			node: func() *corev1.Node {
 				n := newNodeWithCreationTime("node-1", "boot-aaa", nil, time.Now())
 				n.Status.Conditions = nil
@@ -458,25 +458,14 @@ func TestIsNodeReadyForHealthCheck(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "Karpenter initialized — ready (Ready condition not required)",
+			name: "Karpenter initialized — ready for health check (Ready condition not required)",
 			node: newKarpenterNode("node-1", "boot-aaa", nil, time.Now(), true),
 			want: true,
 		},
 		{
-			name: "Karpenter not initialized — not ready",
+			name: "Karpenter not initialized — not ready for health check",
 			node: newKarpenterNode("node-1", "boot-aaa", nil, time.Now(), false),
 			want: false,
-		},
-		{
-			name: "Karpenter initialized but Ready=False — ready (initialized label is sufficient)",
-			node: func() *corev1.Node {
-				n := newKarpenterNode("node-1", "boot-aaa", nil, time.Now(), true)
-				n.Status.Conditions = []corev1.NodeCondition{
-					{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
-				}
-				return n
-			}(),
-			want: true,
 		},
 	}
 	for _, tc := range tests {

--- a/pkg/controller/node/controller_test.go
+++ b/pkg/controller/node/controller_test.go
@@ -432,6 +432,62 @@ func TestRemoveStaleNodeCondition(t *testing.T) {
 	}
 }
 
+func TestIsNodeReadyForHealthCheck(t *testing.T) {
+	tests := []struct {
+		name string
+		node *corev1.Node
+		want bool
+	}{
+		{
+			name: "non-Karpenter Ready=True — ready",
+			node: newNodeWithCreationTime("node-1", "boot-aaa", nil, time.Now()),
+			want: true,
+		},
+		{
+			name: "non-Karpenter Ready=False — not ready",
+			node: newNotReadyNode("node-1", "boot-aaa", nil, time.Now()),
+			want: false,
+		},
+		{
+			name: "non-Karpenter no Ready condition — not ready",
+			node: func() *corev1.Node {
+				n := newNodeWithCreationTime("node-1", "boot-aaa", nil, time.Now())
+				n.Status.Conditions = nil
+				return n
+			}(),
+			want: false,
+		},
+		{
+			name: "Karpenter initialized — ready (Ready condition not required)",
+			node: newKarpenterNode("node-1", "boot-aaa", nil, time.Now(), true),
+			want: true,
+		},
+		{
+			name: "Karpenter not initialized — not ready",
+			node: newKarpenterNode("node-1", "boot-aaa", nil, time.Now(), false),
+			want: false,
+		},
+		{
+			name: "Karpenter initialized but Ready=False — ready (initialized label is sufficient)",
+			node: func() *corev1.Node {
+				n := newKarpenterNode("node-1", "boot-aaa", nil, time.Now(), true)
+				n.Status.Conditions = []corev1.NodeCondition{
+					{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+				}
+				return n
+			}(),
+			want: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isNodeReadyForHealthCheck(tc.node, "boot-aaa"); got != tc.want {
+				t.Errorf("isNodeReadyForHealthCheck = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCreateCheckNodeHealthSkipsWhenNotReady(t *testing.T) {
 	t.Run("not Ready returns (false, nil) and creates no CR", func(t *testing.T) {
 		node := newNotReadyNode("node-1", "boot-aaa", nil, time.Now())
@@ -504,79 +560,6 @@ func TestCreateCheckNodeHealthSkipsWhenNotReady(t *testing.T) {
 		cnh := &chmv1alpha1.CheckNodeHealth{}
 		if err := fc.Get(context.Background(), client.ObjectKey{Name: GenerateCNHName("node-1", "boot-aaa")}, cnh); err != nil {
 			t.Errorf("expected CheckNodeHealth to be created: %v", err)
-		}
-	})
-}
-
-func TestKarpenterHelpers(t *testing.T) {
-	tests := []struct {
-		name            string
-		labels          map[string]string
-		wantManaged     bool
-		wantInitialized bool
-	}{
-		{name: "no labels", labels: nil, wantManaged: false, wantInitialized: false},
-		{
-			name:            "managed (spot) but not initialized",
-			labels:          map[string]string{KarpenterCapacityTypeLabel: "spot"},
-			wantManaged:     true,
-			wantInitialized: false,
-		},
-		{
-			name:            "managed (on-demand) and initialized",
-			labels:          map[string]string{KarpenterCapacityTypeLabel: "on-demand", KarpenterInitializedLabel: "true"},
-			wantManaged:     true,
-			wantInitialized: true,
-		},
-		{
-			name:            "initialized label not 'true'",
-			labels:          map[string]string{KarpenterCapacityTypeLabel: "spot", KarpenterInitializedLabel: "false"},
-			wantManaged:     true,
-			wantInitialized: false,
-		},
-		{
-			name:            "initialized label without capacity-type",
-			labels:          map[string]string{KarpenterInitializedLabel: "true"},
-			wantManaged:     false,
-			wantInitialized: true,
-		},
-		{
-			name:            "capacity-type label present but empty value",
-			labels:          map[string]string{KarpenterCapacityTypeLabel: ""},
-			wantManaged:     false,
-			wantInitialized: false,
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Labels: tc.labels}}
-			if got := isKarpenterManaged(node); got != tc.wantManaged {
-				t.Errorf("isKarpenterManaged = %v, want %v", got, tc.wantManaged)
-			}
-			if got := isKarpenterInitialized(node); got != tc.wantInitialized {
-				t.Errorf("isKarpenterInitialized = %v, want %v", got, tc.wantInitialized)
-			}
-		})
-	}
-}
-
-func TestNotReadyExceedsKarpenterUninitialized(t *testing.T) {
-	t.Run("Karpenter Ready=True not initialized, recent — does not exceed", func(t *testing.T) {
-		node := newKarpenterNode("node-1", "boot-aaa", nil, time.Now(), false)
-		if notReadyExceeds(node, NodeReadyMaxWait) {
-			t.Error("expected notReadyExceeds=false for recently created uninitialized node")
-		}
-	})
-	t.Run("Karpenter Ready=True not initialized, old — exceeds", func(t *testing.T) {
-		node := newKarpenterNode("node-1", "boot-aaa", nil, time.Now().Add(-(NodeReadyMaxWait + time.Minute)), false)
-		if !notReadyExceeds(node, NodeReadyMaxWait) {
-			t.Error("expected notReadyExceeds=true for old uninitialized node")
-		}
-	})
-	t.Run("Karpenter Ready=True initialized — does not exceed", func(t *testing.T) {
-		node := newKarpenterNode("node-1", "boot-aaa", nil, time.Now().Add(-(NodeReadyMaxWait + time.Minute)), true)
-		if notReadyExceeds(node, NodeReadyMaxWait) {
-			t.Error("expected notReadyExceeds=false for initialized Ready=True node")
 		}
 	})
 }


### PR DESCRIPTION
Do not create health check CR until karpenter.sh/initialized=true, otherwise result is not reliable