### PR TITLE
Update go to 1.26.3 and remove image patch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/oss/go/microsoft/golang:1.26.2
+      image: mcr.microsoft.com/oss/go/microsoft/golang:1.26.3
     steps:
       - uses: actions/checkout@v4
       - name: golangci-lint
@@ -30,7 +30,7 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/oss/go/microsoft/golang:1.26.2
+      image: mcr.microsoft.com/oss/go/microsoft/golang:1.26.3
     steps:
       - uses: actions/checkout@v4
       - name: Download dependencies
@@ -46,8 +46,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Microsoft Go
         run: |
-          docker pull mcr.microsoft.com/oss/go/microsoft/golang:1.26.2
-          docker create --name msgo mcr.microsoft.com/oss/go/microsoft/golang:1.26.2
+          docker pull mcr.microsoft.com/oss/go/microsoft/golang:1.26.3
+          docker create --name msgo mcr.microsoft.com/oss/go/microsoft/golang:1.26.3
           docker cp msgo:/usr/local/go "$HOME/microsoft-go"
           docker rm msgo
           echo "$HOME/microsoft-go/bin" >> "$GITHUB_PATH"

--- a/docker/cluster-health-monitor.Dockerfile
+++ b/docker/cluster-health-monitor.Dockerfile
@@ -1,5 +1,5 @@
 # Build the clusterhealthmonitor binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.2 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.3 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -21,27 +21,10 @@ RUN CGO_ENABLED=0 GOEXPERIMENT=ms_nocgo_opensslcrypto go build -o clusterhealthm
 RUN CGO_ENABLED=0 GOEXPERIMENT=ms_nocgo_opensslcrypto go build -o controller cmd/controller/checknodehealth/main.go
 RUN CGO_ENABLED=0 GOEXPERIMENT=ms_nocgo_opensslcrypto go build -o nodechecker cmd/nodechecker/main.go
 
-# Patch the distroless base image with updated openssl packages
-FROM mcr.microsoft.com/azurelinux/distroless/base:3.0 AS distroless-base
-FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS patcher
-RUN tdnf update -y openssl openssl-libs && tdnf clean all
-# Generate updated RPM manifest from distroless base with patched openssl version
-COPY --from=distroless-base /var/lib/rpmmanifest/ /var/lib/rpmmanifest/
-RUN OPENSSL_VERSION=$(rpm -q openssl --qf '%{VERSION}-%{RELEASE}') && \
-    sed -i "s/^openssl\t[^\t]*/openssl\t${OPENSSL_VERSION}/" /var/lib/rpmmanifest/container-manifest-2 && \
-    sed -i "s/^openssl-libs\t[^\t]*/openssl-libs\t${OPENSSL_VERSION}/" /var/lib/rpmmanifest/container-manifest-2 && \
-    sed -i "s/openssl-3\.3\.5-4\.azl3/openssl-${OPENSSL_VERSION}/g" /var/lib/rpmmanifest/container-manifest-2 && \
-    sed -i "s/openssl-3\.3\.5-4\.azl3/openssl-${OPENSSL_VERSION}/g" /var/lib/rpmmanifest/container-manifest-1
-
 # Use distroless as minimal base image to package the clusterhealthmonitor binary
 # Using distroless/base instead of distroless/minimal because it comes with SymCrypt and SymCrypt-OpenSSL which are required FIPS/Azure compliance
 # Refer to https://mcr.microsoft.com/en-us/artifact/mar/azurelinux/distroless/base/about for more details
 FROM mcr.microsoft.com/azurelinux/distroless/base:3.0
-COPY --from=patcher /usr/lib64/libssl.so* /usr/lib64/
-COPY --from=patcher /usr/lib64/libcrypto.so* /usr/lib64/
-COPY --from=patcher /usr/lib64/engines-3/ /usr/lib64/engines-3/
-COPY --from=patcher /usr/lib64/ossl-modules/ /usr/lib64/ossl-modules/
-COPY --from=patcher /var/lib/rpmmanifest/ /var/lib/rpmmanifest/
 WORKDIR /
 COPY --from=builder /workspace/clusterhealthmonitor .
 COPY --from=builder /workspace/controller .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/cluster-health-monitor
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/Azure/aks-health-signal v0.0.0-20260228004220-16040615394b


### PR DESCRIPTION
1. Updating to 1.26.3 to fix https://pkg.go.dev/vuln/GO-2026-4864
2. distroless base already ships openssl-3.3.5-5.azl3, so there is no need to do the patching