### PR TITLE
NAP node check should also wait until core DNS is ready

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/cluster-health-monitor
 
-go 1.26.4
+go 1.26.3
 
 require (
 	github.com/Azure/aks-health-signal v0.0.0-20260228004220-16040615394b

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/cluster-health-monitor
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Azure/aks-health-signal v0.0.0-20260228004220-16040615394b

--- a/pkg/controller/node/controller.go
+++ b/pkg/controller/node/controller.go
@@ -230,16 +230,6 @@ func (r *NodeRebootReconciler) createCheckNodeHealth(ctx context.Context, node *
 // the caller can simply requeue without additional logging. An error is
 // returned only for transient failures (e.g., listing pods).
 func (r *NodeRebootReconciler) isNodeReadyForHealthCheck(ctx context.Context, node *corev1.Node, bootID string) (bool, error) {
-	if isKarpenterManaged(node) {
-		return isKarpenterInitialized(node), nil
-	}
-
-	// Non-Karpenter nodes are considered ready when the node's Ready condition is True and all coreDNS replicas are Ready.
-	if !isNodeReady(node) {
-		klog.InfoS("Node is not Ready yet, deferring CheckNodeHealth creation", "node", node.Name, "bootID", bootID)
-		return false, nil
-	}
-
 	ready, err := r.coreDNSReady(ctx)
 	if err != nil {
 		return false, fmt.Errorf("failed to check CoreDNS readiness: %w", err)
@@ -247,6 +237,19 @@ func (r *NodeRebootReconciler) isNodeReadyForHealthCheck(ctx context.Context, no
 	if !ready {
 		klog.InfoS("CoreDNS Deployment not fully Ready, deferring CheckNodeHealth creation",
 			"node", node.Name, "bootID", bootID)
+		return false, nil
+	}
+
+	if isKarpenterManaged(node) {
+		if !isKarpenterInitialized(node) {
+			klog.InfoS("Karpenter node not initialized yet, deferring CheckNodeHealth creation", "node", node.Name, "bootID", bootID)
+			return false, nil
+		}
+		return true, nil
+	}
+
+	if !isNodeReady(node) {
+		klog.InfoS("Node is not Ready yet, deferring CheckNodeHealth creation", "node", node.Name, "bootID", bootID)
 		return false, nil
 	}
 

--- a/pkg/controller/node/controller_test.go
+++ b/pkg/controller/node/controller_test.go
@@ -533,6 +533,18 @@ func TestIsNodeReadyForHealthCheck(t *testing.T) {
 			want:    false,
 		},
 		{
+			name:    "Karpenter initialized but CoreDNS Deployment not fully Ready — not ready for health check",
+			node:    newKarpenterNode("node-1", "boot-aaa", nil, time.Now(), true),
+			coreDNS: []client.Object{newCoreDNSDeployment(2, 1)},
+			want:    false,
+		},
+		{
+			name:    "Karpenter initialized but CoreDNS Deployment has no Ready replicas — not ready for health check",
+			node:    newKarpenterNode("node-1", "boot-aaa", nil, time.Now(), true),
+			coreDNS: []client.Object{newCoreDNSDeployment(2, 0)},
+			want:    false,
+		},
+		{
 			name: "non-Karpenter node Ready and CoreDNS Spec.Replicas nil with 1 Ready replica — ready (defaults to 1)",
 			node: newNodeWithCreationTime("node-1", "boot-aaa", nil, time.Now()),
 			coreDNS: []client.Object{


### PR DESCRIPTION
NAP node check should also wait until core DNS is ready