### PR TITLE
Update go and trivy versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/oss/go/microsoft/golang:1.26.3
+      image: mcr.microsoft.com/oss/go/microsoft/golang:1.26.4
     steps:
       - uses: actions/checkout@v4
       - name: golangci-lint
@@ -30,7 +30,7 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/oss/go/microsoft/golang:1.26.3
+      image: mcr.microsoft.com/oss/go/microsoft/golang:1.26.4
     steps:
       - uses: actions/checkout@v4
       - name: Download dependencies
@@ -46,8 +46,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Microsoft Go
         run: |
-          docker pull mcr.microsoft.com/oss/go/microsoft/golang:1.26.3
-          docker create --name msgo mcr.microsoft.com/oss/go/microsoft/golang:1.26.3
+          docker pull mcr.microsoft.com/oss/go/microsoft/golang:1.26.4
+          docker create --name msgo mcr.microsoft.com/oss/go/microsoft/golang:1.26.4
           docker cp msgo:/usr/local/go "$HOME/microsoft-go"
           docker rm msgo
           echo "$HOME/microsoft-go/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -41,7 +41,7 @@ jobs:
           PLATFORM: linux/amd64
       
       - name: Run Trivy scan
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
           image-ref: ${{ steps.vars.outputs.image }}
@@ -52,5 +52,6 @@ jobs:
           scanners: vuln,secret
           severity: CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN
           timeout: 5m0s
+          version: v0.71.1
         env:
           TRIVY_DB_REPOSITORY: mcr.microsoft.com/mirror/ghcr/aquasecurity/trivy-db

--- a/docker/cluster-health-monitor.Dockerfile
+++ b/docker/cluster-health-monitor.Dockerfile
@@ -1,5 +1,5 @@
 # Build the clusterhealthmonitor binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.3 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.4 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
Previous failed trivy scan run:
https://github.com/Azure/cluster-health-monitor/actions/runs/27584192993/job/81550896917

1. Detected CVE in go 1.26.3 -> bump to 1.26.4
2. It also mentions a newer trivy version -> bump to 0.71.1