### PR TITLE
limit podstartup nap test to amd skus

### DIFF
--- a/pkg/checker/podstartup/nodepools.go
+++ b/pkg/checker/podstartup/nodepools.go
@@ -88,18 +88,6 @@ func (c *PodStartupChecker) deleteAllKarpenterNodePools(ctx context.Context) err
 	return errors.Join(errs...)
 }
 
-func (c *PodStartupChecker) syntheticNodeTaints() []v1.Taint {
-	return []v1.Taint{
-		{
-			// This taint is to prevent any pods that are not part of the synthetic test from being scheduled on the nodes created by this NodePool.
-			// This is to prevent node consolidation by Karpenter that could potentially disrupt pods and workloads that are not part of the test.
-			// Pods created by the synthetic test are expected to have a toleration for this taint.
-			Key:    c.config.SyntheticPodLabelKey,
-			Effect: v1.TaintEffectNoSchedule,
-		},
-	}
-}
-
 func (c *PodStartupChecker) karpenterNodePool(nodePoolName, timestampStr string) *karpenter.NodePool {
 	return &karpenter.NodePool{
 		TypeMeta: metav1.TypeMeta{
@@ -126,8 +114,24 @@ func (c *PodStartupChecker) karpenterNodePool(nodePoolName, timestampStr string)
 						Kind:  "AKSNodeClass",
 						Name:  "default",
 					},
-					Requirements: []karpenter.NodeSelectorRequirementWithMinValues{},
-					Taints:       c.syntheticNodeTaints(),
+					Requirements: []karpenter.NodeSelectorRequirementWithMinValues{
+						{
+							// Restrict to amd64 skus. In certain regions, arm64 skus have limited capacity and fail to scale up within the
+							// test timeout when selected.
+							NodeSelectorRequirement: v1.NodeSelectorRequirement{
+								Key:      v1.LabelArchStable,
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{karpenter.ArchitectureAmd64},
+							},
+						},
+					},
+					Taints: []v1.Taint{
+						{
+							// Prevent non-synthetic pods from scheduling here, so Karpenter consolidation can't disrupt unrelated workloads.
+							Key:    c.config.SyntheticPodLabelKey,
+							Effect: v1.TaintEffectNoSchedule,
+						},
+					},
 				},
 			},
 		},

--- a/pkg/checker/podstartup/nodepools_test.go
+++ b/pkg/checker/podstartup/nodepools_test.go
@@ -15,30 +15,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	k8stesting "k8s.io/client-go/testing"
+	karpenter "sigs.k8s.io/karpenter/pkg/apis/v1"
 )
 
 const _testSyntheticLabelKey = "test-synthetic-label-key"
-
-func TestSyntheticNodeTaints(t *testing.T) {
-	g := NewWithT(t)
-
-	checker := &PodStartupChecker{
-		dynamicClient: nil, // no client necessary for this test. Just validating the taints.
-		config: &config.PodStartupConfig{
-			SyntheticPodNamespace: "test",
-			SyntheticPodLabelKey:  _testSyntheticLabelKey,
-		},
-	}
-
-	taints := checker.syntheticNodeTaints()
-
-	// Ensure there is a taint to prevent scheduling any pods that are not synthetics created by the checker.
-	// This is to prevent node consolidation by Karpenter that could potentially disrupt pods and workloads that are not part of the test.
-	g.Expect(taints).To(ContainElement(v1.Taint{
-		Key:    _testSyntheticLabelKey,
-		Effect: v1.TaintEffectNoSchedule,
-	}))
-}
 
 func TestKarpenterNodePool(t *testing.T) {
 	g := NewWithT(t)
@@ -62,8 +42,20 @@ func TestKarpenterNodePool(t *testing.T) {
 	// synthetic label is present and timestamp matches what was passed in
 	g.Expect(karpenterNodePool.Labels[_testSyntheticLabelKey]).To(Equal("123456"))
 
-	// taints are set
-	g.Expect(karpenterNodePool.Spec.Template.Spec.Taints).To(Equal(checker.syntheticNodeTaints()))
+	// taint is set
+	g.Expect(karpenterNodePool.Spec.Template.Spec.Taints).To(ContainElement(v1.Taint{
+		Key:    _testSyntheticLabelKey,
+		Effect: v1.TaintEffectNoSchedule,
+	}))
+
+	// amd64 architecture requirement
+	g.Expect(karpenterNodePool.Spec.Template.Spec.Requirements).To(ContainElement(karpenter.NodeSelectorRequirementWithMinValues{
+		NodeSelectorRequirement: v1.NodeSelectorRequirement{
+			Key:      v1.LabelArchStable,
+			Operator: v1.NodeSelectorOpIn,
+			Values:   []string{karpenter.ArchitectureAmd64},
+		},
+	}))
 }
 
 func TestCreateKarpenterNodePool(t *testing.T) {


### PR DESCRIPTION
Limit podstartup nap test to amd skus. In certain regions, arm64 skus have limited capacity and fail to scale up within the test timeout when selected.